### PR TITLE
revert to support flutter version >= 3.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.0
 homepage: https://digital.sbb.ch/de/design-system/mobile/overview/
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
In #115 , the dart SDK was lifted to as high as 3.4.0. I would suggest to aim to support the flutter versions for **half a year**.