### PR TITLE
chore: fix order of android release flow

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout design_system_flutter code.
+        uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"
           cache: "gradle"
-
-      - name: Checkout design_system_flutter code.
-        uses: actions/checkout@v4
 
       - name: Write Keystore from base64 encoded secret.
         id: write_keystore


### PR DESCRIPTION
* first checkout, then java install