### PR TITLE
Chore/add codeowners authorization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, global owners will be requested for review when someone opens a pull request.
+* @SchweizerischeBundesbahnen/DESIGN-SYSTEM-FLUTTER-MAINTAINERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, global owners will be requested for review when someone opens a pull request.
-* @SchweizerischeBundesbahnen/DESIGN-SYSTEM-FLUTTER-MAINTAINERS
+* @SchweizerischeBundesbahnen/SBB-DESIGN-SYSTEM-FLUTTER-MAINTAINERS


### PR DESCRIPTION
The CODEOWNERS file allows to control all changes are only approved by this group of people.

This Github team currently consists of 

* Nicolas Vidoni
* Hoang Tran

All contributions should be made through FORKS and PRs!