### PR TITLE
Fix modal sheet bottom safe area

### DIFF
--- a/lib/src/modal/sbb_modal.dart
+++ b/lib/src/modal/sbb_modal.dart
@@ -108,9 +108,10 @@ Future<T?> showSBBModalSheet<T>({
     enableDrag: enableDrag,
     constraints: constraints,
     builder: (BuildContext context) {
-      return useSafeArea
-          ? _wrapWithBottomSafeArea(SBBModalSheet(title: title, child: child))
-          : SBBModalSheet(title: title, child: child);
+      return SBBModalSheet(
+        title: title,
+        child: useSafeArea ? _wrapWithBottomSafeArea(child) : child,
+      );
     },
     barrierColor: SBBInternal.barrierColor,
   );
@@ -148,9 +149,10 @@ Future<T?> showCustomSBBModalSheet<T>({
     enableDrag: enableDrag,
     constraints: constraints,
     builder: (BuildContext context) {
-      return useSafeArea
-          ? _wrapWithBottomSafeArea(SBBModalSheet.custom(header: header, child: child))
-          : SBBModalSheet.custom(header: header, child: child);
+      return SBBModalSheet.custom(
+        header: header,
+        child: useSafeArea ? _wrapWithBottomSafeArea(child) : child,
+      );
     },
     barrierColor: SBBInternal.barrierColor,
   );


### PR DESCRIPTION
Currently the bottom safe area is applied to the SBBModalSheet itself. This creates an empty space below the model sheet.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-12-14 at 11 13 49](https://github.com/user-attachments/assets/36173113-dbcb-4682-91f8-75432b9e226e)

This PR fixes this by applying the bottom safe area to the child widget of the modal sheet.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-12-14 at 11 15 00](https://github.com/user-attachments/assets/68c134aa-2148-4ddb-a7aa-f2782eccf592)


