### PR TITLE
chore(ci): add pub dev publishing via GitHub actions

### DIFF
--- a/.github/workflows/pubdev-release.yml
+++ b/.github/workflows/pubdev-release.yml
@@ -1,0 +1,12 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,5 +19,5 @@ Merging a pull request with the `autorelease` label will trigger the `github-rel
 
 ##### Pub Dev release
 
-Since the creation of pubdev releases is not currently possible from Github Actions with workflows triggered by
-other bots, the release is done manually by one of the maintainers.
+The creation of a tag in the `github-release` workflow triggers the `pubdev-release` workflow that will complete
+all necessary steps for publishing the package to pubdev.


### PR DESCRIPTION
Previously, the setup was not done on pub dev part. Hence the authentication did not work.