### PR TITLE
Add SBBHeaderbox

### DIFF
--- a/example/lib/native_app.dart
+++ b/example/lib/native_app.dart
@@ -93,10 +93,6 @@ class MyApp extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
                             _DemoEntry(
-                              'HeaderBox',
-                              HeaderBoxPage(),
-                            ),
-                            _DemoEntry(
                               'Icon',
                               IconPage(),
                             ),
@@ -223,6 +219,10 @@ class MyApp extends StatelessWidget {
                             _DemoEntry(
                               'Header',
                               HeaderPage(),
+                            ),
+                            _DemoEntry(
+                              'Headerbox',
+                              HeaderBoxPage(),
                             ),
                             _DemoEntry(
                               'Modal',

--- a/example/lib/native_app.dart
+++ b/example/lib/native_app.dart
@@ -11,6 +11,7 @@ import 'pages/checkbox_page.dart';
 import 'pages/chip_page.dart';
 import 'pages/color_page.dart';
 import 'pages/group_page.dart';
+import 'pages/header_box_page.dart';
 import 'pages/header_page.dart';
 import 'pages/icon_page.dart';
 import 'pages/input_trigger_page.dart';
@@ -91,6 +92,10 @@ class MyApp extends StatelessWidget {
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
+                            _DemoEntry(
+                              'HeaderBox',
+                              HeaderBoxPage(),
+                            ),
                             _DemoEntry(
                               'Icon',
                               IconPage(),

--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -10,9 +10,9 @@ class HeaderBoxPage extends StatefulWidget {
 
 class _HeaderBoxPageState extends State<HeaderBoxPage> {
   final items = <TabBarItem>[
-    _DemoItem(0, SBBIcons.train_small),
-    _DemoItem(1, SBBIcons.station_small),
-    _DemoItem(2, SBBIcons.archive_box_small),
+    _DemoItem(0, SBBIcons.paragraph_small),
+    _DemoItem(1, SBBIcons.lock_closed_small),
+    _DemoItem(2, SBBIcons.arrows_up_down_small),
   ];
 
   late PageController _pageViewController;
@@ -40,19 +40,8 @@ class _HeaderBoxPageState extends State<HeaderBoxPage> {
           physics: NeverScrollableScrollPhysics(),
           controller: _pageViewController,
           children: <Widget>[
-            SBBHeaderbox.custom(
-              flap: SBBHeaderboxFlap(
-                title: 'Heeeeelp',
-                leadingIcon: SBBIcons.dog_small,
-                trailingIcon: SBBIcons.airplane_small,
-              ),
-              child: Row(
-                children: [Icon(SBBIcons.dog_medium), Text('Hello')],
-              ),
-            ),
-            Center(
-              child: Text('Second Page'),
-            ),
+            DesignGuidelinePage(),
+            StaticPage(),
             Center(
               child: Text('Third Page'),
             ),
@@ -75,6 +64,112 @@ class _HeaderBoxPageState extends State<HeaderBoxPage> {
       newPageIndex,
       duration: const Duration(milliseconds: 400),
       curve: Curves.easeInOut,
+    );
+  }
+}
+
+class DesignGuidelinePage extends StatelessWidget {
+  const DesignGuidelinePage({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: sbbDefaultSpacing),
+        const SBBListHeader('Default'),
+        SBBHeaderbox(
+          title: 'Title',
+          leadingIcon: SBBIcons.dog_small,
+          secondaryLabel: 'Subtext',
+          flap: SBBHeaderboxFlap(
+            title: 'Additional text or information',
+            leadingIcon: SBBIcons.sign_exclamation_point_small,
+            trailingIcon: SBBIcons.circle_information_small_small,
+          ),
+          trailingWidget: SBBTertiaryButtonSmall(label: 'Label', icon: SBBIcons.dog_small, onPressed: () {}),
+        ),
+        const SizedBox(height: sbbDefaultSpacing),
+        const SBBListHeader('Large'),
+        SBBHeaderbox.large(
+          title: 'Title',
+          leadingIcon: SBBIcons.dog_medium,
+          secondaryLabel: 'Subtext',
+          trailingWidget: SBBIconButtonLarge(icon: SBBIcons.dog_small, onPressed: () {}),
+        ),
+        const SizedBox(height: sbbDefaultSpacing),
+        const SBBListHeader('Custom'),
+        const SBBHeaderbox.custom(
+          padding: EdgeInsets.zero,
+          flap: SBBHeaderboxFlap.custom(child: Center(child: Text('Choooooo!', style: SBBTextStyles.extraSmallBold))),
+          child: Center(child: Text('🚂｡🚋｡🚋｡🚋｡🚋˙⊹⁺.')),
+        )
+      ],
+    );
+  }
+}
+
+class StaticPage extends StatefulWidget {
+  const StaticPage({
+    super.key,
+  });
+
+  @override
+  State<StaticPage> createState() => _StaticPageState();
+}
+
+class _StaticPageState extends State<StaticPage> {
+  bool _headerBoxExpanded = false;
+  final _expandedHeight = 340.0;
+  final _collapsedHeight = 0.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Stack(
+      children: [
+        _body(),
+        SBBHeaderbox.custom(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Static Screen', style: SBBTextStyles.mediumBold),
+                      Text(
+                        'Click to expand Headerbox.',
+                        style:
+                            SBBTextStyles.smallLight.copyWith(color: isDark ? SBBColors.graphite : SBBColors.granite),
+                      )
+                    ],
+                  ),
+                  SBBTertiaryButtonSmall(
+                      label: 'Expand', onPressed: () => setState(() => _headerBoxExpanded = !_headerBoxExpanded)),
+                ],
+              ),
+              AnimatedContainer(
+                curve: Curves.easeInOut,
+                height: _headerBoxExpanded ? _expandedHeight : _collapsedHeight,
+                duration: Durations.long4,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Center _body() {
+    return Center(
+      child: SBBMessage(
+        title: 'Cover me!',
+        description: 'This screen is non scrollable.\nUsing a stack, the Headerbox will simply lay on top of it.',
+      ),
     );
   }
 }

--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -36,17 +36,16 @@ class _HeaderBoxPageState extends State<HeaderBoxPage> {
     return Column(
       children: [
         Expanded(
-            child: PageView(
-          physics: NeverScrollableScrollPhysics(),
-          controller: _pageViewController,
-          children: <Widget>[
-            DesignGuidelinePage(),
-            StaticPage(),
-            Center(
-              child: Text('Third Page'),
-            ),
-          ],
-        )),
+          child: PageView(
+            physics: NeverScrollableScrollPhysics(),
+            controller: _pageViewController,
+            children: <Widget>[
+              DesignGuidelinePage(),
+              StaticPage(),
+              ScrollablePage(),
+            ],
+          ),
+        ),
         SBBTabBar(
           items: items,
           onTabChanged: (task) async {
@@ -75,6 +74,7 @@ class DesignGuidelinePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final sbbToast = SBBToast.of(context);
     return Column(
       children: [
         const SizedBox(height: sbbDefaultSpacing),
@@ -88,7 +88,11 @@ class DesignGuidelinePage extends StatelessWidget {
             leadingIcon: SBBIcons.sign_exclamation_point_small,
             trailingIcon: SBBIcons.circle_information_small_small,
           ),
-          trailingWidget: SBBTertiaryButtonSmall(label: 'Label', icon: SBBIcons.dog_small, onPressed: () {}),
+          trailingWidget: SBBTertiaryButtonSmall(
+            label: 'Label',
+            icon: SBBIcons.dog_small,
+            onPressed: () => sbbToast.show(message: 'Default pressed', bottom: sbbDefaultSpacing * 6),
+          ),
         ),
         const SizedBox(height: sbbDefaultSpacing),
         const SBBListHeader('Large'),
@@ -96,7 +100,10 @@ class DesignGuidelinePage extends StatelessWidget {
           title: 'Title',
           leadingIcon: SBBIcons.dog_medium,
           secondaryLabel: 'Subtext',
-          trailingWidget: SBBIconButtonLarge(icon: SBBIcons.dog_small, onPressed: () {}),
+          trailingWidget: SBBIconButtonLarge(
+            icon: SBBIcons.dog_small,
+            onPressed: () => sbbToast.show(message: 'Large pressed', bottom: sbbDefaultSpacing * 6),
+          ),
         ),
         const SizedBox(height: sbbDefaultSpacing),
         const SBBListHeader('Custom'),
@@ -168,8 +175,67 @@ class _StaticPageState extends State<StaticPage> {
     return Center(
       child: SBBMessage(
         title: 'Cover me!',
-        description: 'This screen is non scrollable.\nUsing a stack, the Headerbox will simply lay on top of it.',
+        description: 'This screen is non scrollable.\nUsing a Stack, the Headerbox will simply lay on top of it.',
       ),
+    );
+  }
+}
+
+class ScrollablePage extends StatefulWidget {
+  const ScrollablePage({super.key});
+
+  @override
+  State<ScrollablePage> createState() => _ScrollablePageState();
+}
+
+class _ScrollablePageState extends State<ScrollablePage> {
+  bool _headerBoxExpanded = false;
+  final _expandedHeight = 300.0;
+  final _collapsedHeight = 0.0;
+  @override
+  Widget build(BuildContext context) {
+    final sbbToast = SBBToast.of(context);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return CustomScrollView(
+      slivers: [
+        SBBSliverHeaderbox.custom(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Scrollable Screen', style: SBBTextStyles.mediumBold),
+                      Text(
+                        'Click to expand Headerbox.',
+                        style:
+                            SBBTextStyles.smallLight.copyWith(color: isDark ? SBBColors.graphite : SBBColors.granite),
+                      )
+                    ],
+                  ),
+                  SBBTertiaryButtonSmall(
+                      label: 'Expand', onPressed: () => setState(() => _headerBoxExpanded = !_headerBoxExpanded)),
+                ],
+              ),
+              AnimatedContainer(
+                curve: Curves.easeInOut,
+                height: _headerBoxExpanded ? _expandedHeight : _collapsedHeight,
+                duration: Durations.long4,
+              ),
+            ],
+          ),
+        ),
+        SliverList.builder(
+          itemCount: 60,
+          itemBuilder: (context, index) => SBBListItem(
+            title: 'Item $index',
+            onPressed: () => sbbToast.show(message: 'Pressed Item $index', bottom: sbbDefaultSpacing * 6),
+          ),
+        )
+      ],
     );
   }
 }

--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
+
+class HeaderBoxPage extends StatefulWidget {
+  const HeaderBoxPage({super.key});
+
+  @override
+  State<HeaderBoxPage> createState() => _HeaderBoxPageState();
+}
+
+class _HeaderBoxPageState extends State<HeaderBoxPage> {
+  final items = <TabBarItem>[
+    _DemoItem(0, SBBIcons.train_small),
+    _DemoItem(1, SBBIcons.station_small),
+    _DemoItem(2, SBBIcons.archive_box_small),
+  ];
+
+  late PageController _pageViewController;
+  late TabBarController _tabBarController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageViewController = PageController();
+    _tabBarController = TabBarController(items.first);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pageViewController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+            child: PageView(
+          physics: NeverScrollableScrollPhysics(),
+          controller: _pageViewController,
+          children: <Widget>[
+            SBBHeaderbox.custom(
+              flap: SBBHeaderboxFlap(
+                title: 'Heeeeelp',
+                leadingIcon: SBBIcons.dog_small,
+                trailingIcon: SBBIcons.airplane_small,
+              ),
+              child: Row(
+                children: [Icon(SBBIcons.dog_medium), Text('Hello')],
+              ),
+            ),
+            Center(
+              child: Text('Second Page'),
+            ),
+            Center(
+              child: Text('Third Page'),
+            ),
+          ],
+        )),
+        SBBTabBar(
+          items: items,
+          onTabChanged: (task) async {
+            task.then((value) => _handlePageViewChanged(int.parse(value.id)));
+          },
+          controller: _tabBarController,
+          onTap: (tab) {},
+        )
+      ],
+    );
+  }
+
+  void _handlePageViewChanged(int newPageIndex) {
+    _pageViewController.animateToPage(
+      newPageIndex,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeInOut,
+    );
+  }
+}
+
+class _DemoItem extends TabBarItem {
+  _DemoItem(int id, IconData icon) : super(id.toString(), icon);
+
+  @override
+  String translate(BuildContext context) => '';
+}

--- a/lib/sbb_design_system_mobile.dart
+++ b/lib/sbb_design_system_mobile.dart
@@ -10,6 +10,7 @@ export 'src/checkbox/checkbox.dart';
 export 'src/chip/sbb_chip.dart';
 export 'src/group/sbb_group.dart';
 export 'src/header/sbb_header.dart';
+export 'src/headerbox/headerbox.dart';
 export 'src/input_trigger/sbb_input_trigger.dart';
 export 'src/link/sbb_link_text.dart';
 export 'src/list_header/sbb_list_header.dart';

--- a/lib/src/headerbox/headerbox.dart
+++ b/lib/src/headerbox/headerbox.dart
@@ -1,2 +1,3 @@
 export 'sbb_headerbox.dart';
 export 'sbb_headerbox_flap.dart';
+export 'sbb_sliver_headerbox.dart';

--- a/lib/src/headerbox/headerbox.dart
+++ b/lib/src/headerbox/headerbox.dart
@@ -1,0 +1,2 @@
+export 'sbb_headerbox.dart';
+export 'sbb_headerbox_flap.dart';

--- a/lib/src/headerbox/render_sliver_pin_header.dart
+++ b/lib/src/headerbox/render_sliver_pin_header.dart
@@ -1,0 +1,37 @@
+import 'dart:math';
+
+import 'package:flutter/rendering.dart';
+
+class RenderSliverPinHeader extends RenderSliverSingleBoxAdapter {
+  @override
+  void performLayout() {
+    child!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
+    double childExtent;
+    switch (constraints.axis) {
+      case Axis.horizontal:
+        childExtent = child!.size.width;
+        break;
+      case Axis.vertical:
+        childExtent = child!.size.height;
+        break;
+    }
+    final paintedChildExtent = min(
+      childExtent,
+      constraints.remainingPaintExtent - constraints.overlap,
+    );
+    geometry = SliverGeometry(
+      paintExtent: paintedChildExtent,
+      maxPaintExtent: childExtent,
+      maxScrollObstructionExtent: childExtent,
+      paintOrigin: constraints.overlap,
+      scrollExtent: childExtent,
+      layoutExtent: max(0.0, paintedChildExtent - constraints.scrollOffset),
+      hasVisualOverflow: paintedChildExtent < childExtent,
+    );
+  }
+
+  @override
+  double childMainAxisPosition(RenderBox child) {
+    return 0;
+  }
+}

--- a/lib/src/headerbox/sbb_headerbox.dart
+++ b/lib/src/headerbox/sbb_headerbox.dart
@@ -8,7 +8,37 @@ const _headerBoxNavBarExtensionHeight = 24.0;
 const _headerBoxRadius = Radius.circular(sbbDefaultSpacing);
 const _headerBoxFlapTopMargin = 8.0;
 
+/// The SBB Headerbox.
+/// Use according to [documentation](https://digital.sbb.ch/de/design-system/mobile/components/container/)
+///
+/// To place over non scrollable screen content, place this Widget in a [Stack] with the content underneath.
+///
+/// ```dart
+/// @override
+/// Widget build(BuildContext context) {
+///   return Stack(
+///     children: [
+///       _AllTheContentWidget(),
+///       SBBHeaderbox(
+///         title: 'Awesome Headerbox'
+///       ),
+///     ],
+///   );
+/// }
+/// ```
+///
+/// This will lead to the expected behavior of the Headerbox.
+///
+/// See [SBBSliverHeaderbox] for a headerbox that behaves as expected in scrollable content.
 class SBBHeaderbox extends StatelessWidget {
+  /// The default [SBBHeaderbox].
+  ///
+  /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
+  /// displayed below and will wrap to multiple lines.
+  ///
+  /// The trailing widget usually is an action button, e.g. a [SBBTertiaryButtonSmall] with a label and an icon.
+  ///
+  /// For a complete customization of the Headerbox, see the [SBBHeaderbox.custom] constructor.
   SBBHeaderbox({
     Key? key,
     required String title,
@@ -16,33 +46,27 @@ class SBBHeaderbox extends StatelessWidget {
     String? secondaryLabel,
     Widget? trailingWidget,
     SBBHeaderboxFlap? flap,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
   }) : this.custom(
           key: key,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        if (leadingIcon != null) ...[Icon(leadingIcon), SizedBox(width: sbbDefaultSpacing * .5)],
-                        Expanded(child: Text(title, style: SBBTextStyles.mediumBold, overflow: TextOverflow.ellipsis)),
-                      ],
-                    ),
-                    if (secondaryLabel != null)
-                      Text(secondaryLabel, style: SBBTextStyles.smallLight.copyWith(color: SBBColors.granite))
-                  ],
-                ),
-              ),
-              SizedBox(width: sbbDefaultSpacing * .5),
-              if (trailingWidget != null) trailingWidget,
-            ],
+          child: _DefaultHeaderBoxContent(
+            title: title,
+            leadingIcon: leadingIcon,
+            secondaryLabel: secondaryLabel,
+            trailingWidget: trailingWidget,
           ),
+          margin: margin,
           flap: flap,
         );
 
+  /// The large [SBBHeaderbox].
+  ///
+  /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
+  /// displayed below and will wrap to multiple lines.
+  ///
+  /// The trailing widget usually is an action button, e.g. a [SBBIconButtonLarge].
+  ///
+  /// For a complete customization of the Headerbox, see the [SBBHeaderbox.custom] constructor.
   SBBHeaderbox.large({
     Key? key,
     required String title,
@@ -50,28 +74,20 @@ class SBBHeaderbox extends StatelessWidget {
     String? secondaryLabel,
     Widget? trailingWidget,
     SBBHeaderboxFlap? flap,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
   }) : this.custom(
           key: key,
-          child: Row(
-            children: [
-              if (leadingIcon != null) ...[Icon(leadingIcon, size: 36), SizedBox(width: sbbDefaultSpacing * .5)],
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(title, style: SBBTextStyles.mediumBold, overflow: TextOverflow.ellipsis),
-                    SizedBox(height: sbbDefaultSpacing * .25),
-                    if (secondaryLabel != null) Text(secondaryLabel, style: SBBTextStyles.mediumLight)
-                  ],
-                ),
-              ),
-              SizedBox(width: sbbDefaultSpacing * .5),
-              if (trailingWidget != null) trailingWidget,
-            ],
-          ),
           flap: flap,
+          margin: margin,
+          child: _LargeHeaderBoxContent(
+            title: title,
+            leadingIcon: leadingIcon,
+            secondaryLabel: secondaryLabel,
+            trailingWidget: trailingWidget,
+          ),
         );
 
+  /// Allows complete customization of the [SBBHeaderbox].
   const SBBHeaderbox.custom({
     super.key,
     this.margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
@@ -80,9 +96,15 @@ class SBBHeaderbox extends StatelessWidget {
     this.flap,
   });
 
+  /// The margin around the [SBBHeaderbox].
+  ///
+  /// Defaults to EdgeInsets.symmetric(horizonal: 8.0).
   final EdgeInsets margin;
+
   final Widget child;
   final EdgeInsets padding;
+
+  /// The flap to display below the [SBBHeaderbox].
   final SBBHeaderboxFlap? flap;
 
   @override
@@ -171,6 +193,92 @@ class _HeaderBoxBackgroundBar extends StatelessWidget {
         color: headerColorPrimary,
         height: _headerBoxNavBarExtensionHeight,
       ),
+    );
+  }
+}
+
+class _DefaultHeaderBoxContent extends StatelessWidget {
+  const _DefaultHeaderBoxContent({
+    required this.title,
+    this.leadingIcon,
+    this.secondaryLabel,
+    this.trailingWidget,
+  });
+
+  final String title;
+  final IconData? leadingIcon;
+  final String? secondaryLabel;
+  final Widget? trailingWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = SBBHeaderBoxStyle.of(context);
+    final secondaryTextStyle = SBBTextStyles.smallLight.copyWith(color: style.secondaryLabelColor);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  if (leadingIcon != null) ...[
+                    Icon(leadingIcon, size: sbbIconSizeSmall),
+                    SizedBox(width: sbbDefaultSpacing * .5)
+                  ],
+                  Expanded(child: Text(title, style: style.titleTextStyle)),
+                ],
+              ),
+              if (secondaryLabel != null) Text(secondaryLabel!, style: secondaryTextStyle)
+            ],
+          ),
+        ),
+        SizedBox(width: sbbDefaultSpacing * .5),
+        if (trailingWidget != null) trailingWidget!,
+      ],
+    );
+  }
+}
+
+class _LargeHeaderBoxContent extends StatelessWidget {
+  const _LargeHeaderBoxContent({
+    required this.title,
+    this.leadingIcon,
+    this.secondaryLabel,
+    this.trailingWidget,
+  });
+
+  final String title;
+  final IconData? leadingIcon;
+  final String? secondaryLabel;
+  final Widget? trailingWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = SBBHeaderBoxStyle.of(context);
+    final secondaryTextStyle = SBBTextStyles.mediumLight.copyWith(color: style.largeSecondaryLabelColor);
+
+    return Row(
+      children: [
+        if (leadingIcon != null) ...[
+          Icon(leadingIcon, size: sbbIconSizeMedium),
+          SizedBox(width: sbbDefaultSpacing * .5)
+        ],
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: style.titleTextStyle),
+              SizedBox(height: sbbDefaultSpacing * .25),
+              if (secondaryLabel != null) Text(secondaryLabel!, style: secondaryTextStyle)
+            ],
+          ),
+        ),
+        SizedBox(width: sbbDefaultSpacing * .5),
+        if (trailingWidget != null) trailingWidget!,
+      ],
     );
   }
 }

--- a/lib/src/headerbox/sbb_headerbox.dart
+++ b/lib/src/headerbox/sbb_headerbox.dart
@@ -18,7 +18,7 @@ const _headerBoxFlapTopMargin = 8.0;
 /// Widget build(BuildContext context) {
 ///   return Stack(
 ///     children: [
-///       _AllTheContentWidget(),
+///       _PageContentWidget(),
 ///       SBBHeaderbox(
 ///         title: 'Awesome Headerbox'
 ///       ),
@@ -36,7 +36,10 @@ class SBBHeaderbox extends StatelessWidget {
   /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
   /// displayed below and will wrap to multiple lines.
   ///
-  /// The trailing widget usually is an action button, e.g. a [SBBTertiaryButtonSmall] with a label and an icon.
+  /// The design guidelines specify an action button for the [trailingWidget],
+  /// i.e. a [SBBTertiaryButtonSmall] with a label and an icon.
+  ///
+  /// Use the [margin] to adjust space around the Headerbox - the default is horizontal margin of 8px.
   ///
   /// For a complete customization of the Headerbox, see the [SBBHeaderbox.custom] constructor.
   SBBHeaderbox({
@@ -64,7 +67,10 @@ class SBBHeaderbox extends StatelessWidget {
   /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
   /// displayed below and will wrap to multiple lines.
   ///
-  /// The trailing widget usually is an action button, e.g. a [SBBIconButtonLarge].
+  /// The design guidelines specify an action button for the [trailingWidget],
+  /// i.e. a [SBBIconButtonLarge].
+  ///
+  /// Use the [margin] to adjust space around the Headerbox - the default is horizontal margin of 8px.
   ///
   /// For a complete customization of the Headerbox, see the [SBBHeaderbox.custom] constructor.
   SBBHeaderbox.large({
@@ -102,6 +108,8 @@ class SBBHeaderbox extends StatelessWidget {
   final EdgeInsets margin;
 
   final Widget child;
+
+  /// The space around [child].
   final EdgeInsets padding;
 
   /// The flap to display below the [SBBHeaderbox].
@@ -112,14 +120,14 @@ class SBBHeaderbox extends StatelessWidget {
     return Stack(
       children: [
         _HeaderBoxBackgroundBar(),
-        Padding(padding: margin, child: _HeaderBoxTop(padding: padding, flap: flap, child: child)),
+        Padding(padding: margin, child: _HeaderBoxForeground(padding: padding, flap: flap, child: child)),
       ],
     );
   }
 }
 
-class _HeaderBoxTop extends StatelessWidget {
-  const _HeaderBoxTop({
+class _HeaderBoxForeground extends StatelessWidget {
+  const _HeaderBoxForeground({
     required this.child,
     required this.padding,
     this.flap,

--- a/lib/src/headerbox/sbb_headerbox.dart
+++ b/lib/src/headerbox/sbb_headerbox.dart
@@ -9,6 +9,69 @@ const _headerBoxRadius = Radius.circular(sbbDefaultSpacing);
 const _headerBoxFlapTopMargin = 8.0;
 
 class SBBHeaderbox extends StatelessWidget {
+  SBBHeaderbox({
+    Key? key,
+    required String title,
+    IconData? leadingIcon,
+    String? secondaryLabel,
+    Widget? trailingWidget,
+    SBBHeaderboxFlap? flap,
+  }) : this.custom(
+          key: key,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        if (leadingIcon != null) ...[Icon(leadingIcon), SizedBox(width: sbbDefaultSpacing * .5)],
+                        Expanded(child: Text(title, style: SBBTextStyles.mediumBold, overflow: TextOverflow.ellipsis)),
+                      ],
+                    ),
+                    if (secondaryLabel != null)
+                      Text(secondaryLabel, style: SBBTextStyles.smallLight.copyWith(color: SBBColors.granite))
+                  ],
+                ),
+              ),
+              SizedBox(width: sbbDefaultSpacing * .5),
+              if (trailingWidget != null) trailingWidget,
+            ],
+          ),
+          flap: flap,
+        );
+
+  SBBHeaderbox.large({
+    Key? key,
+    required String title,
+    IconData? leadingIcon,
+    String? secondaryLabel,
+    Widget? trailingWidget,
+    SBBHeaderboxFlap? flap,
+  }) : this.custom(
+          key: key,
+          child: Row(
+            children: [
+              if (leadingIcon != null) ...[Icon(leadingIcon, size: 36), SizedBox(width: sbbDefaultSpacing * .5)],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: SBBTextStyles.mediumBold, overflow: TextOverflow.ellipsis),
+                    SizedBox(height: sbbDefaultSpacing * .25),
+                    if (secondaryLabel != null) Text(secondaryLabel, style: SBBTextStyles.mediumLight)
+                  ],
+                ),
+              ),
+              SizedBox(width: sbbDefaultSpacing * .5),
+              if (trailingWidget != null) trailingWidget,
+            ],
+          ),
+          flap: flap,
+        );
+
   const SBBHeaderbox.custom({
     super.key,
     this.margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
@@ -75,10 +138,7 @@ class _HeaderBoxTop extends StatelessWidget {
       ),
       constraints: BoxConstraints(minHeight: _headerBoxMinHeight, minWidth: double.infinity),
       padding: padding,
-      child: Card(
-        color: SBBColors.transparent,
-        child: child,
-      ),
+      child: child,
     );
   }
 

--- a/lib/src/headerbox/sbb_headerbox.dart
+++ b/lib/src/headerbox/sbb_headerbox.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../../sbb_design_system_mobile.dart';
+import '../sbb_internal.dart';
+
+const _headerBoxMinHeight = 56.0;
+const _headerBoxNavBarExtensionHeight = 24.0;
+const _headerBoxRadius = Radius.circular(sbbDefaultSpacing);
+const _headerBoxFlapTopMargin = 8.0;
+
+class SBBHeaderbox extends StatelessWidget {
+  const SBBHeaderbox.custom({
+    super.key,
+    this.margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
+    required this.child,
+    this.padding = const EdgeInsets.all(sbbDefaultSpacing),
+    this.flap,
+  });
+
+  final EdgeInsets margin;
+  final Widget child;
+  final EdgeInsets padding;
+  final SBBHeaderboxFlap? flap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        _HeaderBoxBackgroundBar(),
+        Padding(padding: margin, child: _HeaderBoxTop(padding: padding, flap: flap, child: child)),
+      ],
+    );
+  }
+}
+
+class _HeaderBoxTop extends StatelessWidget {
+  const _HeaderBoxTop({
+    required this.child,
+    required this.padding,
+    this.flap,
+  });
+
+  final EdgeInsets padding;
+  final Widget child;
+  final Widget? flap;
+
+  @override
+  Widget build(BuildContext context) {
+    return flap != null ? _flappedHeaderBox(context) : _headerBox(context);
+  }
+
+  Widget _flappedHeaderBox(BuildContext context) {
+    return Container(
+      decoration: _flappedBackgroundDecoration(context),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(bottom: _headerBoxFlapTopMargin),
+            child: _headerBox(context),
+          ),
+          flap!,
+        ],
+      ),
+    );
+  }
+
+  Widget _headerBox(BuildContext context) {
+    final SBBHeaderBoxStyle style = SBBHeaderBoxStyle.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: style.backgroundColor,
+        borderRadius: BorderRadius.all(_headerBoxRadius),
+        boxShadow: _headerBoxShadow,
+      ),
+      constraints: BoxConstraints(minHeight: _headerBoxMinHeight, minWidth: double.infinity),
+      padding: padding,
+      child: Card(
+        color: SBBColors.transparent,
+        child: child,
+      ),
+    );
+  }
+
+  BoxDecoration _flappedBackgroundDecoration(BuildContext context) {
+    final Color flapBackgroundColor = SBBHeaderBoxStyle.of(context).flapBackgroundColor!;
+    return BoxDecoration(
+      boxShadow: SBBInternal.defaultBoxShadow,
+      borderRadius: BorderRadius.only(bottomLeft: _headerBoxRadius, bottomRight: _headerBoxRadius),
+      gradient: LinearGradient(
+        begin: Alignment.bottomCenter,
+        end: Alignment.topCenter,
+        colors: [flapBackgroundColor, flapBackgroundColor, SBBColors.white.withAlpha(0)],
+        stops: [0.0, 0.5, 1.0],
+      ),
+    );
+  }
+
+  List<BoxShadow> get _headerBoxShadow =>
+      [BoxShadow(color: SBBColors.black.withAlpha(32), blurRadius: 4.0, offset: Offset(0, 2.0))];
+}
+
+class _HeaderBoxBackgroundBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // take AppBar background color to align with e.g. SBBHeader
+    final Color? headerColorPrimary = Theme.of(context).appBarTheme.backgroundColor;
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Container(
+        color: headerColorPrimary,
+        height: _headerBoxNavBarExtensionHeight,
+      ),
+    );
+  }
+}

--- a/lib/src/headerbox/sbb_headerbox_flap.dart
+++ b/lib/src/headerbox/sbb_headerbox_flap.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
+
+const _flapBorderRadius = BorderRadius.only(
+  bottomLeft: Radius.circular(sbbDefaultSpacing),
+  bottomRight: Radius.circular(sbbDefaultSpacing),
+);
+
+const _flapIconSize = 24.0;
+
+/// Use in combination with the [SBBHeaderbox] for the [flap] argument.
+///
+/// See [HeaderBox in documentation](https://digital.sbb.ch/de/design-system/mobile/components/container/).
+///
+/// For a complete custom variant, use the [custom] constructor.
+class SBBHeaderboxFlap extends StatelessWidget {
+  SBBHeaderboxFlap({
+    Key? key,
+    required String title,
+    bool allowMultilineLabel = true,
+    IconData? leadingIcon,
+    IconData? trailingIcon,
+  }) : this.custom(
+          key: key,
+          child: _buildDefaultFlap(title, allowMultilineLabel, leadingIcon, trailingIcon),
+        );
+
+  /// Allows complete customization of the content of the [SBBHeaderboxFlap].
+  const SBBHeaderboxFlap.custom({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.fromLTRB(
+      sbbDefaultSpacing,
+      0.0, // margin from [SBBHeaderBox] to allow shadow
+      sbbDefaultSpacing,
+      sbbDefaultSpacing * .5,
+    ),
+  });
+
+  /// The padding for the content of the [SBBHeaderboxFlap].
+  final EdgeInsets padding;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color? flapColor = SBBHeaderBoxStyle.of(context).flapBackgroundColor;
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: flapColor,
+        borderRadius: _flapBorderRadius,
+      ),
+      child: child,
+    );
+  }
+
+  static Widget _buildDefaultFlap(
+    String title,
+    bool allowMultilineLabel,
+    IconData? leadingIcon,
+    IconData? trailingIcon,
+  ) {
+    return Row(
+      children: [
+        if (leadingIcon != null) ...[
+          Icon(leadingIcon, size: _flapIconSize),
+          SizedBox(width: sbbDefaultSpacing * .5),
+        ],
+        Expanded(
+          child: Text(
+            title,
+            maxLines: allowMultilineLabel ? null : 1,
+            overflow: allowMultilineLabel ? null : TextOverflow.ellipsis,
+          ),
+        ),
+        if (trailingIcon != null) ...[
+          SizedBox(width: sbbDefaultSpacing * .5),
+          Icon(trailingIcon, size: _flapIconSize),
+        ]
+      ],
+    );
+  }
+}

--- a/lib/src/headerbox/sbb_headerbox_flap.dart
+++ b/lib/src/headerbox/sbb_headerbox_flap.dart
@@ -72,6 +72,7 @@ class SBBHeaderboxFlap extends StatelessWidget {
             title,
             maxLines: allowMultilineLabel ? null : 1,
             overflow: allowMultilineLabel ? null : TextOverflow.ellipsis,
+            style: SBBTextStyles.smallLight,
           ),
         ),
         if (trailingIcon != null) ...[

--- a/lib/src/headerbox/sbb_sliver_headerbox.dart
+++ b/lib/src/headerbox/sbb_sliver_headerbox.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../../sbb_design_system_mobile.dart';
+import 'render_sliver_pin_header.dart';
+
+/// The SBB Sliver Headerbox.
+/// Use according to [documentation](https://digital.sbb.ch/de/design-system/mobile/components/container/)
+///
+/// Allows using the SBB Headerbox in a scrollable content.
+/// Place this Widget in a [CustomScrollView].
+///
+/// ```dart
+/// @override
+/// Widget build(BuildContext context) {
+///   return CustomScrollView(
+///     slivers: [
+///       SBBSliverHeaderbox(title: 'My awesome Headerbox'),
+///       SliverList.builder(
+///         itemCount: 60,
+///         itemBuilder: (context, index) => SBBListItem(
+///           title: 'Item $index',
+///           onPressed: () {},
+///         ),
+///       ),
+///     ],
+///   );
+/// }
+/// ```
+///
+/// This will lead to the expected behavior of the SBB Headerbox.
+///
+/// See [SBBHeaderbox] for a headerbox that behaves as expected in non scrollable content.
+class SBBSliverHeaderbox extends SingleChildRenderObjectWidget {
+  /// The default [SBBSliverHeaderbox].
+  ///
+  /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
+  /// displayed below and will wrap to multiple lines.
+  ///
+  /// The design guidelines specify an action button for the [trailingWidget],
+  /// i.e. a [SBBTertiaryButtonSmall] with a label and an icon.
+  ///
+  /// Use the [margin] to adjust space around the Headerbox - the default is horizontal margin of 8px.
+  ///
+  /// For a complete customization of the Headerbox, see the [SBBSliverHeaderbox.custom] constructor.
+  SBBSliverHeaderbox({
+    super.key,
+    required String title,
+    IconData? leadingIcon,
+    String? secondaryLabel,
+    Widget? trailingWidget,
+    SBBHeaderboxFlap? flap,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
+  }) : super(
+          child: SBBHeaderbox(
+            title: title,
+            leadingIcon: leadingIcon,
+            secondaryLabel: secondaryLabel,
+            trailingWidget: trailingWidget,
+            margin: margin,
+            flap: flap,
+          ),
+        );
+
+  /// The large [SBBSliverHeaderbox].
+  ///
+  /// The required argument [title] will be ellipsed if too long. The [secondaryLabel] is the subtext
+  /// displayed below and will wrap to multiple lines.
+  ///
+  /// The design guidelines specify an action button for the [trailingWidget],
+  /// i.e. a [SBBIconButtonLarge].
+  ///
+  /// Use the [margin] to adjust space around the Headerbox - the default is horizontal margin of 8px.
+  ///
+  /// For a complete customization of the Headerbox, see the [SBBSliverHeaderbox.custom] constructor.
+  SBBSliverHeaderbox.large({
+    super.key,
+    required String title,
+    IconData? leadingIcon,
+    String? secondaryLabel,
+    Widget? trailingWidget,
+    SBBHeaderboxFlap? flap,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
+  }) : super(
+          child: SBBHeaderbox.large(
+            title: title,
+            leadingIcon: leadingIcon,
+            secondaryLabel: secondaryLabel,
+            trailingWidget: trailingWidget,
+            margin: margin,
+            flap: flap,
+          ),
+        );
+
+  /// Allows complete customization of the [SBBSliverHeaderbox].
+  SBBSliverHeaderbox.custom({
+    super.key,
+    required Widget child,
+    EdgeInsets margin = const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing * .5),
+    EdgeInsets padding = const EdgeInsets.all(sbbDefaultSpacing),
+    SBBHeaderboxFlap? flap,
+  }) : super(
+          child: SBBHeaderbox.custom(
+            margin: margin,
+            padding: padding,
+            flap: flap,
+            child: child,
+          ),
+        );
+
+  @override
+  RenderSliverPinHeader createRenderObject(BuildContext context) {
+    return RenderSliverPinHeader();
+  }
+}

--- a/lib/src/theme/sbb_theme.dart
+++ b/lib/src/theme/sbb_theme.dart
@@ -12,6 +12,7 @@ class SBBTheme {
     SBBBaseStyle? baseStyle,
     SBBButtonStyles? buttonStyles,
     SBBControlStyles? controlStyles,
+    SBBHeaderBoxStyle? headerBoxStyle,
   }) =>
       createTheme(
         brightness: Brightness.light,
@@ -19,6 +20,7 @@ class SBBTheme {
         baseStyle: baseStyle,
         buttonStyles: buttonStyles,
         controlStyles: controlStyles,
+        headerBoxStyle: headerBoxStyle,
       );
 
   static ThemeData dark({
@@ -26,6 +28,7 @@ class SBBTheme {
     SBBBaseStyle? baseStyle,
     SBBButtonStyles? buttonStyles,
     SBBControlStyles? controlStyles,
+    SBBHeaderBoxStyle? headerBoxStyle,
   }) =>
       createTheme(
         brightness: Brightness.dark,
@@ -33,6 +36,7 @@ class SBBTheme {
         baseStyle: baseStyle,
         buttonStyles: buttonStyles,
         controlStyles: controlStyles,
+        headerBoxStyle: headerBoxStyle,
       );
 
   static ThemeData createTheme({
@@ -41,6 +45,7 @@ class SBBTheme {
     SBBBaseStyle? baseStyle,
     SBBButtonStyles? buttonStyles,
     SBBControlStyles? controlStyles,
+    SBBHeaderBoxStyle? headerBoxStyle,
   }) {
     // SET hard-coded default values HERE
     final defaultBaseStyle = SBBBaseStyle.$default(
@@ -59,11 +64,17 @@ class SBBTheme {
     );
     final mergedControlStyles = controlStyles.merge(defaultControlStyles);
 
+    final defaultHeaderBoxStyle = SBBHeaderBoxStyle.$default(
+      baseStyle: mergedBaseStyle,
+    );
+    final mergedHeaderBoxStyle = headerBoxStyle.merge(defaultHeaderBoxStyle);
+
     return raw(
       brightness: brightness,
       baseStyle: mergedBaseStyle,
       buttonStyles: mergedButtonStyles,
       controlStyles: mergedControlStyles,
+      headerBoxStyle: mergedHeaderBoxStyle,
     );
   }
 
@@ -72,6 +83,7 @@ class SBBTheme {
     required SBBBaseStyle baseStyle,
     required SBBButtonStyles buttonStyles,
     required SBBControlStyles controlStyles,
+    required SBBHeaderBoxStyle headerBoxStyle,
   }) =>
       ThemeData(
         colorScheme: ColorScheme.fromSwatch(
@@ -108,6 +120,7 @@ class SBBTheme {
           baseStyle,
           buttonStyles,
           controlStyles,
+          headerBoxStyle,
         ],
       );
 

--- a/lib/src/theme/styles/sbb_styles.dart
+++ b/lib/src/theme/styles/sbb_styles.dart
@@ -20,3 +20,4 @@ export 'src/sbb_slider_style.dart';
 export 'src/sbb_switch_style.dart';
 export 'src/sbb_text_field_style.dart';
 export 'src/sbb_text_style.dart';
+export 'src/sbb_headerbox_style.dart';

--- a/lib/src/theme/styles/src/sbb_headerbox_style.dart
+++ b/lib/src/theme/styles/src/sbb_headerbox_style.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../../sbb_design_system_mobile.dart';
+
+class SBBHeaderBoxStyle extends ThemeExtension<SBBHeaderBoxStyle> {
+  SBBHeaderBoxStyle({
+    this.backgroundColor,
+    this.flapBackgroundColor,
+  });
+
+  factory SBBHeaderBoxStyle.$default({required SBBBaseStyle baseStyle}) => SBBHeaderBoxStyle(
+        backgroundColor: baseStyle.themeValue(SBBColors.white, SBBColors.charcoal),
+        flapBackgroundColor: baseStyle.themeValue(SBBColors.cloud, SBBColors.midnight),
+      );
+
+  static SBBHeaderBoxStyle of(BuildContext context) => Theme.of(context).extension<SBBHeaderBoxStyle>()!;
+
+  final Color? backgroundColor;
+  final Color? flapBackgroundColor;
+
+  @override
+  SBBHeaderBoxStyle copyWith({
+    Color? backgroundColor,
+    Color? flapBackgroundColor,
+  }) =>
+      SBBHeaderBoxStyle(
+        backgroundColor: backgroundColor ?? this.backgroundColor,
+        flapBackgroundColor: flapBackgroundColor ?? this.flapBackgroundColor,
+      );
+
+  @override
+  SBBHeaderBoxStyle lerp(SBBHeaderBoxStyle? other, double t) => SBBHeaderBoxStyle(
+        backgroundColor: Color.lerp(backgroundColor, other?.backgroundColor, t),
+        flapBackgroundColor: Color.lerp(flapBackgroundColor, other?.flapBackgroundColor, t),
+      );
+}
+
+extension SBBHeaderBoxStyleExtension on SBBHeaderBoxStyle? {
+  SBBHeaderBoxStyle merge(SBBHeaderBoxStyle? other) {
+    if (this == null) return other ?? SBBHeaderBoxStyle();
+    return this!.copyWith(
+      backgroundColor: this!.backgroundColor ?? other?.backgroundColor,
+      flapBackgroundColor: this!.flapBackgroundColor ?? other?.flapBackgroundColor,
+    );
+  }
+}

--- a/lib/src/theme/styles/src/sbb_headerbox_style.dart
+++ b/lib/src/theme/styles/src/sbb_headerbox_style.dart
@@ -4,17 +4,26 @@ import '../../../../sbb_design_system_mobile.dart';
 
 class SBBHeaderBoxStyle extends ThemeExtension<SBBHeaderBoxStyle> {
   SBBHeaderBoxStyle({
+    this.titleTextStyle,
+    this.secondaryLabelColor,
+    this.largeSecondaryLabelColor,
     this.backgroundColor,
     this.flapBackgroundColor,
   });
 
   factory SBBHeaderBoxStyle.$default({required SBBBaseStyle baseStyle}) => SBBHeaderBoxStyle(
+        titleTextStyle: SBBTextStyles.mediumBold.copyWith(overflow: TextOverflow.ellipsis),
+        secondaryLabelColor: baseStyle.themeValue(SBBColors.granite, SBBColors.graphite),
+        largeSecondaryLabelColor: baseStyle.defaultTextColor,
         backgroundColor: baseStyle.themeValue(SBBColors.white, SBBColors.charcoal),
         flapBackgroundColor: baseStyle.themeValue(SBBColors.cloud, SBBColors.midnight),
       );
 
   static SBBHeaderBoxStyle of(BuildContext context) => Theme.of(context).extension<SBBHeaderBoxStyle>()!;
 
+  final TextStyle? titleTextStyle;
+  final Color? secondaryLabelColor;
+  final Color? largeSecondaryLabelColor;
   final Color? backgroundColor;
   final Color? flapBackgroundColor;
 


### PR DESCRIPTION
This PR adds the SBBHeaderbox.

See the documentation [here](https://digital.sbb.ch/de/design-system/mobile/components/container/).
See the specs [here](https://www.figma.com/design/WOtLIam1xwrqcgnAITsEhV/Design-System-Mobile?node-id=6128-12137&t=AUH8WQ0LgpGUTQj3-0)

There are two variants for placing the Headerbox in different types of contents:

1. The SBBHeaderbox for placing it in non scrollable content / pages.
2. The SBBSliverHeaderbox for placing it in scrollable content inside a CustomScrollView.

The documentation is added. The Headerbox merges Semantics together using a MergeSemantics widget.
