### PR TITLE
chore(ci): enforce pub dev publication validation in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
           path: test/failures/
           retention-days: 3
 
+      - name: Check publishable to pub.dev
+        run: flutter pub publish --dry-run
+
   changelog-test:
     runs-on: ubuntu-latest
     steps:

--- a/.pubignore
+++ b/.pubignore
@@ -112,3 +112,6 @@ example/.metadata
 
 # failed golden tests
 test/failures
+
+# font tool
+tool/font_scripts/**


### PR DESCRIPTION
This PR does two things:

* It resolves the issues for pub dev publishing by adding the tool/font_scripts section in the `.pubignore` file.
* It add the check in test whether this package is currently publishable.

This allows the main branch to always be in a **releasable** state, the next step in the Continuous Deployment journey.
