### PR TITLE
feat: add onChangeStart and onChangeEnd to SBBSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ It is expected that you keep this format strictly, since we depend on it in our 
 - added `custom` constructor to `SBBPromotionBox` to allow for complete control over the content
 - added `copyWith` to `PromotionBoxStyle`
 - added `showCloseButton` and `backgroundColor` to `SBBModalPopup` and `SBBModalSheet` and their show methods
+- added `onChangeStart` and `onChangeEnd` to `SBBSlider`
 
 ### Changed
 

--- a/lib/src/slider/sbb_slider.dart
+++ b/lib/src/slider/sbb_slider.dart
@@ -17,6 +17,12 @@ const _iconPadding = 4.0;
 ///
 /// Use [SBBSliderStyle] to customize the slider theme.
 ///
+/// [onChangeStart] is called when the user starts to select a new value for
+/// the slider.
+///
+/// [onChangeEnd] is called when the user is done selecting a new value for
+/// the slider.
+///
 /// See also:
 ///
 /// * <https://digital.sbb.ch/de/design-system/mobile/components/slider>
@@ -29,9 +35,13 @@ class SBBSlider extends StatelessWidget {
     this.max = 1.0,
     this.startIcon = SBBIcons.walk_slow_small,
     this.endIcon = SBBIcons.walk_fast_small,
+    this.onChangeStart,
+    this.onChangeEnd,
   });
 
   final ValueChanged<double>? onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
   final double value;
   final double min;
   final double max;
@@ -96,6 +106,8 @@ class SBBSlider extends StatelessWidget {
           min: min,
           max: max,
           onChanged: onChanged,
+          onChangeStart: onChangeStart,
+          onChangeEnd: onChangeEnd,
         ),
       ),
     );

--- a/test/sbb_slider_test.dart
+++ b/test/sbb_slider_test.dart
@@ -20,6 +20,8 @@ void main() {
           max: 100,
           startIcon: null,
           endIcon: null,
+          onChangeStart: (value) {},
+          onChangeEnd: (value) {},
         ),
         const SizedBox(height: sbbDefaultSpacing),
         const SBBSlider(


### PR DESCRIPTION
I noticed that the `SBBSlider` lacks events to detect the start and end of an interaction, so I added them.

Background:

I want to propagate the selected value to my back end when the user finishes moving the slider. I guess I could also do a debounce, but this seems cleaner to me, since it's supported by the official slider widget.