### PR TITLE
Fix for Issue #284 (Autocomplete onChanged behavior not working)

### DIFF
--- a/example/lib/pages/autocompletion_page.dart
+++ b/example/lib/pages/autocompletion_page.dart
@@ -28,6 +28,9 @@ class AutocompletionPageState extends State<AutocompletionPage> {
       itemSubmitted: (String submitted) {
         debugPrint('Item submitted: $submitted');
       },
+      onChanged: (value) {
+        debugPrint('onChanged: $value');
+      },
       suggestions: [
         'aaa',
         'aaa1',

--- a/lib/src/text/sbb_autocompletion.dart
+++ b/lib/src/text/sbb_autocompletion.dart
@@ -191,6 +191,8 @@ class SBBAutocompletionState<T> extends State<SBBAutocompletion<T>> with Widgets
     if (widget.controller?.text != null) {
       _currentText = widget.controller!.text;
     }
+
+    _textChanged = (value) => widget.onChanged?.call(value);
   }
 
   @override
@@ -295,14 +297,13 @@ class SBBAutocompletionState<T> extends State<SBBAutocompletion<T>> with Widgets
                                     () {
                                       final String newText = favorite.toString();
                                       _textField.controller?.text = newText;
+                                      _textChanged?.call(newText);
                                       if (widget.submitOnSuggestionTap) {
                                         _textField.focusNode?.unfocus();
                                         widget.itemSubmitted(favorite);
                                         if (widget.clearOnSubmit) {
                                           clear();
                                         }
-                                      } else {
-                                        _textChanged?.call(newText);
                                       }
                                     },
                                   );
@@ -329,14 +330,13 @@ class SBBAutocompletionState<T> extends State<SBBAutocompletion<T>> with Widgets
                                 setState(() {
                                   final String newText = suggestion.toString();
                                   _textField.controller?.text = newText;
+                                  _textChanged?.call(newText);
                                   if (widget.submitOnSuggestionTap) {
                                     _textField.focusNode?.unfocus();
                                     widget.itemSubmitted(suggestion);
                                     if (widget.clearOnSubmit) {
                                       clear();
                                     }
-                                  } else {
-                                    _textChanged?.call(newText);
                                   }
                                 });
                               },


### PR DESCRIPTION
I used the already existing `_textChanged` StringCallback to fire the onChanged from the widget whenever the text is changed or a selection is made.