### PR TITLE
chore: migrated cardTheme to cardThemeData

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "3.24.5", "3.32.x" ]
+        sdk: [ "3.27.0", "3.32.x" ]
     steps:
       - uses: actions/checkout@v4
 
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "3.24.5", "3.32.x" ]
+        sdk: [ "3.27.0", "3.32.x" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.29.x
+          flutter-version: 3.32.x
           cache: true
 
       - name: Flutter doctor
@@ -75,13 +75,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "3.24.5", "3.29.x" ]
+        sdk: [ "3.24.5", "3.32.x" ]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
           cache: "gradle"
 
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "3.24.5", "3.29.x" ]
+        sdk: [ "3.24.5", "3.32.x" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ It is expected that you keep this format strictly, since we depend on it in our 
 ### Changed
 
 - updated the SBB Icons version to 1.6.2
+- Dropped support for `Flutter SDK 3.24.5`: minimum supported version is 3.27.0
 
 ## [3.0.0] - 2025-04-24
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -61,6 +61,7 @@
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral/
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -32,7 +32,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace 'ch.sbb.fdsm.example'
-    compileSdkVersion 34
+    compileSdkVersion 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -43,8 +43,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     defaultConfig {

--- a/example/lib/pages/checkbox_page.dart
+++ b/example/lib/pages/checkbox_page.dart
@@ -136,8 +136,7 @@ class CheckboxPageState extends State<CheckboxPage> {
         const SizedBox(height: sbbDefaultSpacing),
         const SBBListHeader('Checkbox Item - Boxed'),
         Column(
-          // spacing: sbbDefaultSpacing * 0.5,  add once support for Flutter SDK 3.24.5 removed
-          // and remove SizedBoxes below
+          spacing: sbbDefaultSpacing * 0.5,
           children: [
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
@@ -147,7 +146,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 onChanged: _isEnabled ? (value) => setState(() => _listItemValue1 = value) : null,
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue2,
@@ -156,7 +154,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 onChanged: _isEnabled ? (value) => setState(() => _listItemValue2 = value) : null,
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue4,
@@ -165,7 +162,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 leadingIcon: SBBIcons.alarm_clock_small,
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue5,
@@ -175,7 +171,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 trailingIcon: SBBIcons.dog_small,
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue3,
@@ -185,7 +180,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 onCallToAction: () => sbbToast.show(message: 'Button pressed'),
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.custom(
                 value: _listItemValue6,
@@ -200,7 +194,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 ),
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue7,
@@ -212,7 +205,6 @@ class CheckboxPageState extends State<CheckboxPage> {
                 onChanged: _isEnabled ? (value) => setState(() => _listItemValue7 = value) : null,
               ),
             ),
-            SizedBox(height: sbbDefaultSpacing * .5),
             SBBGroup(
               child: SBBCheckboxListItem.boxed(
                 value: _listItemValue8,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  auto_route: ^10.0.1
+  auto_route: ^9.0.0
 
   # https://pub.dev/packages/provider
   provider: ^6.1.5
@@ -33,8 +33,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  auto_route_generator: ^10.0.1
-  build_runner: ^2.4.15
+  auto_route_generator: ^9.0.0
+  build_runner: ^2.1.10
 
 flutter:
   uses-material-design: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,16 +13,16 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  auto_route: ^9.0.0
+  auto_route: ^10.0.1
 
   # https://pub.dev/packages/provider
-  provider: ^6.0.2
+  provider: ^6.1.5
 
   # https://pub.dev/packages/animations
-  animations: ^2.0.3
+  animations: ^2.0.11
 
   # https://pub.dev/packages/flutter_svg
-  flutter_svg: ^2.0.6
+  flutter_svg: ^2.1.0
 
   # https://pub.dev/packages/intl
   intl: '>=0.19.0 <0.21.0'
@@ -33,8 +33,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  auto_route_generator: ^9.0.0
-  build_runner: ^2.1.10
+  auto_route_generator: ^10.0.1
+  build_runner: ^2.4.15
 
 flutter:
   uses-material-design: true

--- a/lib/src/theme/styles/src/sbb_control_styles.dart
+++ b/lib/src/theme/styles/src/sbb_control_styles.dart
@@ -115,7 +115,7 @@ class SBBControlStyles extends ThemeExtension<SBBControlStyles> {
         centerTitle: true,
       );
 
-  CardTheme get cardTheme => CardTheme(
+  CardThemeData get cardTheme => CardThemeData(
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(sbbDefaultSpacing)),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # https://pub.dev/packages/intl
   intl: '>=0.19.0 <0.21.0'
   # https://pub.dev/packages/collection
-  collection: ^1.19.0
+  collection: ^1.18.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # https://pub.dev/packages/intl
   intl: '>=0.19.0 <0.21.0'
   # https://pub.dev/packages/collection
-  collection: ^1.18.0
+  collection: ^1.19.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ topics: [ icons, theme, design, design-system ]
 version: 3.0.0 # automatically set by GH Action 
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.24.0"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:

--- a/test/sbb_radio_test.dart
+++ b/test/sbb_radio_test.dart
@@ -145,8 +145,7 @@ class RadioTest extends StatelessWidget {
           const SizedBox(height: sbbDefaultSpacing),
           const SBBListHeader('RadioButton Item - List'),
           Column(
-            // spacing: sbbDefaultSpacing * 0.5,  add once support for Flutter SDK 3.24.5 removed
-            // and remove SizedBoxes below
+            spacing: sbbDefaultSpacing * 0.5,
             children: [
               SBBGroup(
                 child: SBBRadioListItem<int>.boxed(
@@ -156,7 +155,6 @@ class RadioTest extends StatelessWidget {
                   label: 'Label',
                 ),
               ),
-              SizedBox(height: sbbDefaultSpacing * .5),
               SBBGroup(
                 child: SBBRadioListItem<int>.boxed(
                   value: 2,
@@ -167,7 +165,6 @@ class RadioTest extends StatelessWidget {
                   trailingIcon: SBBIcons.dog_small,
                 ),
               ),
-              SizedBox(height: sbbDefaultSpacing * .5),
               SBBGroup(
                 child: SBBRadioListItem<int>.boxed(
                   value: 3,
@@ -178,7 +175,6 @@ class RadioTest extends StatelessWidget {
                   onCallToAction: () => {},
                 ),
               ),
-              SizedBox(height: sbbDefaultSpacing * .5),
               SBBGroup(
                 child: SBBRadioListItem<int>.custom(
                   value: 4,


### PR DESCRIPTION
This migration is needed to support Flutter version 3.32.0. For more informations check the [release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.32.0).