### PR TITLE
fix: make sure tap events are fired for selected tabs

### DIFF
--- a/lib/src/shared/tapable_element.dart
+++ b/lib/src/shared/tapable_element.dart
@@ -3,29 +3,37 @@ import 'package:flutter/material.dart';
 import '../../sbb_design_system_mobile.dart';
 
 class TapableElement extends StatelessWidget {
-  factory TapableElement.roundedBox({Key? key, GestureTapCallback? onTap, Widget? child}) {
+  factory TapableElement.roundedBox({Key? key, GestureTapCallback? onTap, Color? color, Widget? child}) {
     return TapableElement(
       key: key,
       customBorder: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(sbbDefaultSpacing))),
       onTap: onTap,
+      color: color,
       child: child,
     );
   }
 
-  factory TapableElement.circle({Key? key, GestureTapCallback? onTap, Widget? child}) =>
-      TapableElement(key: key, customBorder: const CircleBorder(), onTap: onTap, child: child);
+  factory TapableElement.circle({Key? key, GestureTapCallback? onTap, Color? color, Widget? child}) => TapableElement(
+    key: key,
+    customBorder: const CircleBorder(),
+    onTap: onTap,
+    color: color,
+    child: child,
+  );
 
-  const TapableElement({super.key, this.customBorder, this.onTap, this.child});
+  const TapableElement({super.key, this.customBorder, this.onTap, this.color, this.child});
 
   final ShapeBorder? customBorder;
   final GestureTapCallback? onTap;
   final Widget? child;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final iconStyle = SBBButtonStyles.of(context).iconTextStyle;
     return Material(
-      color: SBBColors.transparent,
+      color: color ?? SBBColors.transparent,
+      shape: customBorder,
       child: InkWell(
         focusColor: iconStyle?.backgroundColorHighlighted,
         hoverColor: iconStyle?.backgroundColorHighlighted,

--- a/lib/src/tab_bar/sbb_tab_bar.dart
+++ b/lib/src/tab_bar/sbb_tab_bar.dart
@@ -110,8 +110,14 @@ class _SBBTabBarState extends State<SBBTabBar> with SingleTickerProviderStateMix
                   child: Stack(
                     children: [
                       ..._tabs.mapIndexed(
-                        (i, e) =>
-                            Positioned(left: layoutData.positions[i].dx, child: TabItemWidget(e.icon, selected: true)),
+                        (i, e) => Positioned(
+                          left: layoutData.positions[i].dx,
+                          child: TabItemWidget(
+                            e.icon,
+                            selected: true,
+                            onTap: () => _onTap(e, navData),
+                          ),
+                        ),
                       ),
                       CustomPaint(
                         painter: TabCurvePainter(_controller.curves, cardColor, theme.shadowColor),
@@ -123,11 +129,7 @@ class _SBBTabBarState extends State<SBBTabBar> with SingleTickerProviderStateMix
                             warnings: warnings,
                             portrait: portrait,
                             onPositioned: _controller.onLayout,
-                            onTap: (e) {
-                              widget.onTap.call(e);
-                              if (navData.selectedTab == e) return;
-                              widget.onTabChanged(_controller.selectTab(e));
-                            },
+                            onTap: (e) => _onTap(e, navData),
                             onTapDown: (e) {
                               if (navData.selectedTab == e) return;
                               _controller.hoverTab(e);
@@ -145,5 +147,11 @@ class _SBBTabBarState extends State<SBBTabBar> with SingleTickerProviderStateMix
         );
       },
     );
+  }
+
+  void _onTap(SBBTabBarItem item, SBBTabBarNavigationData navData) {
+    widget.onTap.call(item);
+    if (navData.selectedTab == item) return;
+    widget.onTabChanged(_controller.selectTab(item));
   }
 }

--- a/lib/src/tab_bar/tab_curve_painter.dart
+++ b/lib/src/tab_bar/tab_curve_painter.dart
@@ -28,6 +28,13 @@ class TabCurvePainter extends CustomPainter {
   }
 
   @override
+  bool? hitTest(Offset position) {
+    // Prevent the paint from stopping pointer events from reaching the icons underneath.
+    // Hit tests still reach the children of the paint.
+    return false;
+  }
+
+  @override
   bool shouldRepaint(TabCurvePainter oldDelegate) =>
       oldDelegate.color != color ||
       oldDelegate.shadowColor != shadowColor ||

--- a/lib/src/tab_bar/tab_item_widget.dart
+++ b/lib/src/tab_bar/tab_item_widget.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:sbb_design_system_mobile/src/shared/tapable_element.dart';
 
 import '../../sbb_design_system_mobile.dart';
 
 class TabItemWidget extends StatelessWidget {
-  const TabItemWidget(this.icon, {super.key, this.selected = false, this.warning});
+  const TabItemWidget(
+    this.icon, {
+    super.key,
+    this.selected = false,
+    this.warning,
+    this.onTap,
+  });
 
   static const portraitSize = 44.0;
   static const landscapeSize = 36.0;
@@ -15,6 +22,7 @@ class TabItemWidget extends StatelessWidget {
   final IconData icon;
   final bool selected;
   final SBBTabBarWarningSetting? warning;
+  final Function()? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -27,27 +35,26 @@ class TabItemWidget extends StatelessWidget {
     final backgroundColor = style.themeValue(SBBColors.black, SBBColors.white);
     Color iconColor = selected ? foregroundColor : backgroundColor;
 
-    BoxDecoration? decoration;
-    Color? containerColor = SBBColors.transparent;
+    Color? color;
     IconData resolvedIcon = icon;
 
     if (warning != null && !warning!.shown) {
-      decoration = const BoxDecoration(color: SBBColors.red, shape: BoxShape.circle);
-      containerColor = null;
+      color = SBBColors.red;
       iconColor = SBBColors.white;
       resolvedIcon = SBBIcons.sign_exclamation_point_small;
     } else if (selected) {
-      decoration = BoxDecoration(color: backgroundColor, shape: BoxShape.circle);
-      containerColor = null;
+      color = backgroundColor;
     }
 
     return Container(
       width: size,
       height: size,
       margin: EdgeInsets.only(top: topPadding, left: horizontalCirclePadding, right: horizontalCirclePadding),
-      color: containerColor,
-      decoration: decoration,
-      child: Icon(resolvedIcon, color: iconColor),
+      child: TapableElement.circle(
+        color: color,
+        onTap: onTap,
+        child: Icon(resolvedIcon, color: iconColor),
+      ),
     );
   }
 }


### PR DESCRIPTION
My latest change introduced an issue with the tap handler of the tab bar icon:
Because of the new clipper, the  tap event is no longer fired on icons that are clipped away.

I tried to fix this by adding an additional tap handler to the icon underneath (with an InkWell so that it looks nice and matches the behavior of the SBB App... 😋).