### PR TITLE
fix: improve state management of tab bar

### DIFF
--- a/example/lib/pages/tab_bar_page.dart
+++ b/example/lib/pages/tab_bar_page.dart
@@ -46,7 +46,9 @@ class TabBarPageState extends State<TabBarPage> {
               onTabChanged: (task) async {},
               controller: controller,
               onTap: (tab) {
-                sbbToast.show(title: 'Tab tapped: Item ${tab.id}', bottom: sbbDefaultSpacing * 7.0);
+                if (controller.selectedTab == tab) {
+                  sbbToast.show(title: 'Tab tapped: Item ${tab.id}', bottom: sbbDefaultSpacing * 7.0);
+                }
               },
             ),
           ),

--- a/lib/src/tab_bar/sbb_tab_bar.dart
+++ b/lib/src/tab_bar/sbb_tab_bar.dart
@@ -79,16 +79,14 @@ class _SBBTabBarState extends State<SBBTabBar> with TickerProviderStateMixin, Wi
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.controller != widget.controller || oldWidget.items != widget.items) {
-      setState(() {
-        // Clean up
-        _controller.dispose();
-        for (var it in _focusNodes.values) {
-          it.dispose();
-        }
+      // Clean up
+      _controller.dispose();
+      for (var it in _focusNodes.values) {
+        it.dispose();
+      }
 
-        // Rebind
-        _initController();
-      });
+      // Rebind
+      _initController();
     }
   }
 
@@ -111,7 +109,7 @@ class _SBBTabBarState extends State<SBBTabBar> with TickerProviderStateMixin, Wi
   @override
   Widget build(context) {
     return StreamBuilder<SBBTabBarLayoutData>(
-      key: Key('${_controller.hashCode}'),
+      key: ValueKey(_controller),
       stream: _controller.layoutStream,
       initialData: _controller.currentLayoutData,
       builder: (context, snapshot) {

--- a/lib/src/tab_bar/sbb_tab_bar_controller.dart
+++ b/lib/src/tab_bar/sbb_tab_bar_controller.dart
@@ -134,4 +134,11 @@ class SBBTabBarController {
     currentLayoutData = SBBTabBarLayoutData(height, positions);
     _layoutController.add(currentLayoutData);
   }
+
+  void dispose() {
+    _animationController.dispose();
+    _layoutController.close();
+    _navigationController.close();
+    _warningController.close();
+  }
 }


### PR DESCRIPTION
`SBBTabBar` has two constructors:

1. One that takes a controller (which is probably kept in the caller's state).
2. One that takes a list of items and creates a controller on the fly.

The former is without major problems, but the latter has the issue that the controller is prone to changing, and thus violating some basic preconditions of the widget.

This commit tries to mitigate this issue by managing the controller in its own state, and, when the items change, recreating the controller and rebinding the ticker.

Related issue:
closes #381 