### PR TITLE
feat: allow overriding SystemUiOverlayStyle on SBBHeader (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ It is expected that you keep this format strictly, since we depend on it in our 
 ### Added
 - added functional colors (e.g. `SBBColors.error`) and dark variants of additionalColors (e.g. `SBBColors.skyDark`)
 - added `errorColor` to `SBBBaseStyle`
+- added `systemOverlayStyle` to `SBBHeader`
 
 ## [4.1.0] - 2025-08-22
 

--- a/example/lib/native_app.dart
+++ b/example/lib/native_app.dart
@@ -1,5 +1,6 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -69,7 +70,10 @@ class MyApp extends StatelessWidget {
             supportedLocales: const [Locale('en'), Locale('de'), Locale('fr'), Locale('it')],
             locale: const Locale('de'),
             home: Scaffold(
-              appBar: const SBBHeader(title: 'Design System Mobile'),
+              appBar: const SBBHeader(
+                title: 'Design System Mobile',
+                systemOverlayStyle: SystemUiOverlayStyle.light,
+              ),
               body: SingleChildScrollView(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: sbbDefaultSpacing),

--- a/lib/src/header/sbb_header.dart
+++ b/lib/src/header/sbb_header.dart
@@ -20,6 +20,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
     VoidCallback? onPressedLogo,
     String? logoTooltip,
     bool? blockSemantics,
+    SystemUiOverlayStyle? systemOverlayStyle,
   }) : this._(
          key: key,
          title: title,
@@ -30,6 +31,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
          onPressedLogo: onPressedLogo,
          logoTooltip: logoTooltip,
          blockSemantics: blockSemantics,
+         systemOverlayStyle: systemOverlayStyle,
        );
 
   const SBBHeader.menu({
@@ -40,6 +42,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
     List<Widget>? actions,
     String? logoTooltip,
     bool? blockSemantics,
+    SystemUiOverlayStyle? systemOverlayStyle,
   }) : this._(
          key: key,
          title: title,
@@ -50,6 +53,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
          actions: actions,
          logoTooltip: logoTooltip,
          blockSemantics: blockSemantics,
+         systemOverlayStyle: systemOverlayStyle,
        );
 
   const SBBHeader.back({
@@ -60,6 +64,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
     List<Widget>? actions,
     String? logoTooltip,
     bool? blockSemantics,
+    SystemUiOverlayStyle? systemOverlayStyle,
   }) : this._(
          key: key,
          title: title,
@@ -70,6 +75,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
          actions: actions,
          logoTooltip: logoTooltip,
          blockSemantics: blockSemantics,
+         systemOverlayStyle: systemOverlayStyle,
        );
 
   const SBBHeader.close({
@@ -80,6 +86,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
     List<Widget>? actions,
     String? logoTooltip,
     bool? blockSemantics,
+    SystemUiOverlayStyle? systemOverlayStyle,
   }) : this._(
          key: key,
          title: title,
@@ -90,22 +97,24 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
          actions: actions,
          logoTooltip: logoTooltip,
          blockSemantics: blockSemantics,
+         systemOverlayStyle: systemOverlayStyle,
        );
 
   const SBBHeader._({
     super.key,
     required this.title,
+    required this.automaticallyImplyLeading,
+    required this.onPressedLogo,
+    required this.logoTooltip,
     this.leadingWidget,
     this.leadingWidth,
-    required this.automaticallyImplyLeading,
     this.useMenuButton = false,
     this.useBackButton = false,
     this.useCloseButton = false,
     this.onPressed,
-    required this.onPressedLogo,
-    required this.logoTooltip,
     this.actions,
     this.blockSemantics,
+    this.systemOverlayStyle,
   }) : assert(actions == null || onPressedLogo == null);
 
   final String title;
@@ -120,6 +129,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
   final String? logoTooltip;
   final List<Widget>? actions;
   final bool? blockSemantics;
+  final SystemUiOverlayStyle? systemOverlayStyle;
 
   static const _menuButtonIconWidth = 20.718;
   static const _menuButtonIconHeight = 16.0;
@@ -173,7 +183,7 @@ class SBBHeader extends StatelessWidget implements PreferredSizeWidget {
     return BlockSemantics(
       blocking: blockSemantics ?? false,
       child: AppBar(
-        systemOverlayStyle: SystemUiOverlayStyle(systemNavigationBarColor: SBBColors.transparent),
+        systemOverlayStyle: systemOverlayStyle ?? SystemUiOverlayStyle(systemNavigationBarColor: SBBColors.transparent),
         titleSpacing: 0.0,
         leading: Container(
           padding: customLeadingWidth ? EdgeInsets.zero : EdgeInsets.only(right: kToolbarHeight - leadingWidth),


### PR DESCRIPTION
<img width="1069" height="155" alt="image" src="https://github.com/user-attachments/assets/a285891b-8acf-4dde-8abf-206cca47201e" />
<img width="1070" height="147" alt="image" src="https://github.com/user-attachments/assets/bed03a58-9ebb-4367-a818-0350ffc132d6" />
