### PR TITLE
chore(ci): add nightly workflow to update icon lib

### DIFF
--- a/.github/actions/icon-lib-changelog-generator/action.yml
+++ b/.github/actions/icon-lib-changelog-generator/action.yml
@@ -1,0 +1,19 @@
+name: 'icon-lib-changelog-generator'
+description: 'Updates the given CHANGELOG with the given icon lib version using update-changelog.sh'
+inputs:
+  version:
+    description: 'The version of the icon lib'
+    required: true
+  changelog-path:
+    description: 'The path to the changelog file'
+    required: true
+    default: 'CHANGELOG.md'
+runs:
+  using: "composite"
+  steps:
+    - name: Run update-changelog.sh
+      env:
+        VERSION: ${{ inputs.version }}
+        CHANGELOG_FILE: ${{ inputs.changelog-path }}
+      run: .github/actions/icon-lib-changelog-generator/update-changelog.sh "$VERSION" "$CHANGELOG_FILE"
+      shell: bash

--- a/.github/actions/icon-lib-changelog-generator/update-changelog.sh
+++ b/.github/actions/icon-lib-changelog-generator/update-changelog.sh
@@ -1,0 +1,92 @@
+# This script updates the "Unreleased" section of a CHANGELOG file to include or modify
+# an entry for updating the icon lib version. It ensures that the entry is added
+# or updated in the appropriate location within the "### Changed" subsection of the
+# "## [Unreleased]" section.
+#
+# Usage:
+#   ./update-changelog.sh <version> <changelog_file>
+#
+# Arguments:
+#   <version>        The version of the icon library to be added or updated.
+#   <changelog_file> The path to the CHANGELOG file to be modified.
+#
+# Behavior:
+# - If the "## [Unreleased]" section does not contain a "### Changed" subsection,
+#   it will be created.
+# - If an entry for the icon library update already exists, it will be updated
+#   with the provided version.
+# - If no entry exists, a new entry will be added to the "### Changed" subsection.
+#
+# Requirements:
+# - The specified CHANGELOG file must exist.
+# - The script requires `awk` to process the file.
+#
+# Example:
+#   ./update-changelog.sh 1.2.3 CHANGELOG.md
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <version> <changelog_file>"
+  exit 1
+fi
+
+VERSION="$1"
+CHANGELOG_FILE="$2"
+
+if [ ! -f "$CHANGELOG_FILE" ]; then
+  echo "Error: File '$CHANGELOG_FILE' not found!"
+  exit 1
+fi
+
+awk -v version="$VERSION" '
+BEGIN {
+  unreleased_found = 0
+  changed_found = 0
+  changed_entries_found = 0
+  entry_added = 0
+}
+{
+  if (entry_added) {
+    print $0
+    next
+  }
+
+  if ($0 ~ /^## \[Unreleased\]/) {
+    unreleased_found = 1
+    print $0
+    next
+  }
+
+  if (unreleased_found && $0 ~ /^### Changed/) {
+    changed_found = 1
+    print $0
+    next
+  }
+
+  if (unreleased_found && changed_found && $0 ~ /^\- \(auto\): updated icon lib to version /) {
+    $0 = "- (auto): updated icon lib to version " version
+    entry_added = 1
+    print $0
+    next
+  }
+
+  if (unreleased_found && changed_found && !changed_entries_found && $0 !~ /^$/) {
+    changed_entries_found = 1
+    print $0
+    next
+  }
+
+  if (unreleased_found && changed_found && changed_entries_found && !entry_added && $0 ~ /^$/) {
+    # changed section is over without having added the line
+    $0 = "- (auto): updated icon lib to version " version "\n"
+    entry_added = 1
+  }
+  if (unreleased_found && !changed_found && $0 ~ /^## /) {
+    # unreleased section is over without changed
+    $0 = "### Changed\n\n- (auto): updated icon lib to version " version "\n\n" $0
+    entry_added = 1
+  }
+
+  print $0
+}' "$CHANGELOG_FILE" > "${CHANGELOG_FILE}.tmp"
+
+mv "${CHANGELOG_FILE}.tmp" "$CHANGELOG_FILE"

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -3,7 +3,7 @@ name: nightly_build
 on:
   workflow_dispatch:
   schedule:
-    - cron: "40 2 * * *" # 02:20 am every day
+    - cron: "40 2 * * *" # 02:40 am every day
 
 jobs:
   test:

--- a/.github/workflows/nightly-update-icon-lib.yml
+++ b/.github/workflows/nightly-update-icon-lib.yml
@@ -1,0 +1,139 @@
+# This workflow updates the icon font used by this package to match the version found at https://icons.app.sbb.ch.
+# If there is a new version, it will create / update a pull request.
+# It is run every night.
+#
+# The icons can be browsed on https://digital.sbb.ch/de/foundation/assets/icons/
+# They are guaranteed to be always backward compatible,
+# meaning that no icons will disappear or renamed in a minor or patch update.
+name: nightly_update_icon_lib
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 3 * * *" # 03:20 am every day
+
+jobs:
+  # runs the font tool and will upload artifact with generated files if new version available
+  font-tool:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./tool/font_scripts
+    outputs:
+      has_version_update: ${{ steps.gitDiff.outputs.has_diff }}
+
+    steps:
+
+      - uses: actions/checkout@v5
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.9
+
+      - name: Install Dart dependencies
+        run: dart pub get
+
+      - name: Install Node.js dependencies
+        run: npm i
+
+      - name: Run update script
+        run: dart lib/update_icon_fonts.dart
+
+      - name: Move files to correct dirs if exist
+        shell: bash {0}
+        run: |
+          icons_dir="${GITHUB_WORKSPACE}/lib/src/theme/icons"
+          fonts_dir="${GITHUB_WORKSPACE}/lib/fonts"
+          shopt -s nullglob
+          for file in ./icons/*.ttf; do
+            mv -f "$file" "$fonts_dir"/
+          done
+          for file in ./icons/*.dart; do
+            mv -f "$file" "$icons_dir"/
+          done
+          shopt -u nullglob
+
+      - name: Diffing and file operations # checks git diff and moves all relevant files to artifact dir
+        id: gitDiff
+        shell: bash {0}
+        run: |
+          test -n "$(git status "${GITHUB_WORKSPACE}/lib" --porcelain)"
+          has_diff=$?
+          echo "has_diff=${has_diff}" >> "$GITHUB_OUTPUT"
+          if (( has_diff == 0 )); then
+            mkdir "${GITHUB_WORKSPACE}/artifacts"
+            cp "${GITHUB_WORKSPACE}"/lib/fonts/sbb_icons_*.ttf "${GITHUB_WORKSPACE}"/artifacts
+            cp "${GITHUB_WORKSPACE}"/lib/src/theme/icons/sbb_*.dart "${GITHUB_WORKSPACE}"/artifacts
+            cp ./icons/.version "${GITHUB_WORKSPACE}"/artifacts/
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: artifacts/
+          include-hidden-files: true
+          if-no-files-found: ignore # artifact dir will be empty if no relevant update
+          retention-days: 1
+
+  pull-request-opener:
+    # adapts Changelog and opens PR with correct label
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    needs: font-tool
+    if: needs.font-tool.outputs.has_version_update == 0
+
+    steps:
+
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APPBAKERYGITHUBAPP_APPID }}
+          private-key: ${{ secrets.APPBAKERYGITHUBAPP_PRIVATEKEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: artifacts/
+
+      - name: Version Number
+        id: version_number
+        run: |
+          icon_version="$(cat ./artifacts/.version)"
+          echo "version=${icon_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Move files
+        shell: bash {0}
+        run: |
+          icons_dir="${GITHUB_WORKSPACE}/lib/src/theme/icons"
+          fonts_dir="${GITHUB_WORKSPACE}/lib/fonts"
+          mv -f ./artifacts/.version ./tool/font_scripts/icons
+          mv -f ./artifacts/sbb_icons*.ttf "$fonts_dir"
+          mv -f ./artifacts/sbb_*.dart "$icons_dir"
+
+      - name: Add or update CHANGELOG entry
+        uses: ./.github/actions/icon-lib-changelog-generator
+        with:
+          version: ${{ steps.version_number.outputs.version }}
+          changelog-path: ./CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
+          branch: update-icon-lib
+          title: ${{ format('feat{0} update icon lib version to {1}', ':', steps.version_number.outputs.version) }}
+          commit-message: |
+            ${{ format('feat{0} update to icon lib version {1}', ':', steps.version_number.outputs.version) }}
+            
+            This is an automatic commit.
+            * updates icon lib files
+            * updates CHANGELOG

--- a/.github/workflows/nightly-update-icon-lib.yml
+++ b/.github/workflows/nightly-update-icon-lib.yml
@@ -61,10 +61,13 @@ jobs:
           has_diff=$?
           echo "has_diff=${has_diff}" >> "$GITHUB_OUTPUT"
           if (( has_diff == 0 )); then
+            echo "Version update contains relevant updates."
             mkdir "${GITHUB_WORKSPACE}/artifacts"
             cp "${GITHUB_WORKSPACE}"/lib/fonts/sbb_icons_*.ttf "${GITHUB_WORKSPACE}"/artifacts
             cp "${GITHUB_WORKSPACE}"/lib/src/theme/icons/sbb_*.dart "${GITHUB_WORKSPACE}"/artifacts
             cp ./icons/.version "${GITHUB_WORKSPACE}"/artifacts/
+          else 
+            echo "Version update does not contain relevant updates."
           fi
 
       - name: Upload artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ It is expected that you keep this format strictly, since we depend on it in our 
 
 ### Changed
 
-- updated icon lib to version 1.8.9
+- (auto): updated icon lib to version 1.8.9
 - aligned SBBColors to colors in Figma and specs
 - error color in SBBTheme is used from `SBBBaseStyle.errorColor`
 - use functional colors as in specs for `SBBStatus` and `SBBNotificationBox`
 
 ### Added
+
 - added functional colors (e.g. `SBBColors.error`) and dark variants of additionalColors (e.g. `SBBColors.skyDark`)
 - added `errorColor` to `SBBBaseStyle`
 - added `systemOverlayStyle` to `SBBHeader`

--- a/tool/font_scripts/lib/update_icon_fonts.dart
+++ b/tool/font_scripts/lib/update_icon_fonts.dart
@@ -88,13 +88,13 @@ Future<void> prepareIcons(String type, List<dynamic> icons) async {
       final svgUri = makeUrlUri(fileName);
 
       futures.add(
-          downloadSvg(svgUri, fileName.replaceAll('-', '_'), dir.path, client).then((_) => progress.increment()));
+        downloadSvg(svgUri, fileName.replaceAll('-', '_'), dir.path, client).then((_) => progress.increment()),
+      );
       if (i % 20 == 0) await Future.wait(futures); // otherwise host closes connection
       i++;
     }
     await Future.wait(futures);
-  }
-  finally {
+  } finally {
     client.close();
   }
 }


### PR DESCRIPTION
This PR adds a nightly workflow to run the `tool/font_scripts` utility script. The workflow will be run every night at 3:20am.

It will check the version of the icons found at https://icons.app.sbb.ch/ to the version specificed in `tool/font_scripts/icons/.version` and update accordingly.

If the update contains changes that resolve in a git diff with the current files (font files (`.ttf`) or `sbb_icons.dart` file), it will update the Changelog and open a PR.

The Changelog will be updated in the ## Unreleased section under ### Changed (it will create this section if not existent yet) and will add / update a line to mark the version update.


Also, the script was slightly modified to make multiple requests in parallel for faster execution. 

======

closes #320 

