### PR TITLE
chore: minimify package size by excluding goldens

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -40,6 +40,9 @@ build/
 # failed golden tests
 test/failures
 
+# golden files
+test/goldens
+
 # ============== TOOLS
 tool/**
 


### PR DESCRIPTION
Compresses archive size from 10MB to ~2MB.

Doing something for the environment on Thursday afternoon.