### PR TITLE
chore(ci): use macos-26 in CI

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
 
@@ -70,7 +70,7 @@ jobs:
   build-iOS:
     name: Build iOS
     needs: [ test ]
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
 
@@ -104,7 +104,7 @@ jobs:
 
   build-iOS:
     name: Build Example App iOS
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [ test, changelog-test ]
     defaults:
       run:


### PR DESCRIPTION
As the macos-26 images were made generally available yesterday, switch to using them now.