### PR TITLE
fix: open up headerbox for semantics customizaiton

### DIFF
--- a/lib/src/headerbox/sbb_headerbox.dart
+++ b/lib/src/headerbox/sbb_headerbox.dart
@@ -163,12 +163,10 @@ class _HeaderBoxForeground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MergeSemantics(
-      child: Semantics(
-        header: true,
-        label: semanticsLabel,
-        child: flap != null ? _flappedHeaderBox(context) : _headerBox(context),
-      ),
+    return Semantics(
+      header: true,
+      label: semanticsLabel,
+      child: flap != null ? _flappedHeaderBox(context) : _headerBox(context),
     );
   }
 

--- a/lib/src/headerbox/sbb_sliver_floating_headerbox.headerbox.dart
+++ b/lib/src/headerbox/sbb_sliver_floating_headerbox.headerbox.dart
@@ -78,12 +78,10 @@ class _HeaderBoxForeground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MergeSemantics(
-      child: Semantics(
-        header: true,
-        label: semanticsLabel,
-        child: flap != null ? _flappedHeaderBox(context) : _headerBox(context),
-      ),
+    return Semantics(
+      header: true,
+      label: semanticsLabel,
+      child: flap != null ? _flappedHeaderBox(context) : _headerBox(context),
     );
   }
 


### PR DESCRIPTION
Be very careful with MergeSemantics.
With this, Interactive child Widgets cannot be navigated to separately.