### PR TITLE
feat!: migrate remaining WidgetStateProperty<TextStyle?>? to TextStyle?

### DIFF
--- a/lib/src/chip/sbb_chip.dart
+++ b/lib/src/chip/sbb_chip.dart
@@ -151,8 +151,8 @@ class _SBBChipState extends State<SBBChip> {
     final backgroundColor = effectiveStyle.backgroundColor!.resolve(states);
     final labelForegroundColor = effectiveStyle.labelForegroundColor!.resolve(states);
     final trailingForegroundColor = effectiveStyle.trailingForegroundColor!.resolve(states);
-    final labelTextStyle = effectiveStyle.labelTextStyle!.resolve(states);
-    final trailingTextStyle = effectiveStyle.trailingTextStyle!.resolve(states);
+    final labelTextStyle = effectiveStyle.labelTextStyle;
+    final trailingTextStyle = effectiveStyle.trailingTextStyle;
     final trailingBackgroundColor = effectiveStyle.trailingBackgroundColor!.resolve(states);
 
     return ClipPath(

--- a/lib/src/chip/theme/default_sbb_chip_theme_data.dart
+++ b/lib/src/chip/theme/default_sbb_chip_theme_data.dart
@@ -22,13 +22,8 @@ class DefaultSBBChipThemeData extends SBBChipThemeData {
             WidgetState.selected: baseStyle.colorScheme.iconPrimary,
             WidgetState.any: SBBColors.white,
           }),
-          labelTextStyle: WidgetStateProperty.fromMap(<WidgetStatesConstraint, TextStyle?>{
-            WidgetState.disabled: baseStyle.themedTextStyle(textStyle: baseStyle.textTheme.mediumLight),
-            WidgetState.any: baseStyle.themedTextStyle(textStyle: baseStyle.textTheme.mediumLight),
-          }),
-          trailingTextStyle: WidgetStatePropertyAll(
-            baseStyle.themedTextStyle(textStyle: baseStyle.textTheme.smallBold),
-          ),
+          labelTextStyle: baseStyle.textTheme.mediumLight,
+          trailingTextStyle: baseStyle.textTheme.smallBold,
           trailingBackgroundColor: WidgetStateProperty.fromMap(<WidgetStatesConstraint, Color?>{
             WidgetState.selected & WidgetState.disabled: baseStyle.themeValue(SBBColors.milk, SBBColors.iron),
             WidgetState.disabled: baseStyle.themeValue(SBBColors.graphite, SBBColors.iron),

--- a/lib/src/chip/theme/sbb_chip_style.dart
+++ b/lib/src/chip/theme/sbb_chip_style.dart
@@ -61,7 +61,7 @@ class SBBChipStyle {
   ///
   /// The color of the [labelTextStyle] is typically not used directly, the
   /// [labelForegroundColor] is used instead.
-  final WidgetStateProperty<TextStyle?>? labelTextStyle;
+  final TextStyle? labelTextStyle;
 
   /// The text style for the trailing badge text.
   ///
@@ -69,7 +69,7 @@ class SBBChipStyle {
   ///
   /// The color of the [trailingTextStyle] is typically not used directly, the
   /// [trailingForegroundColor] is used instead.
-  final WidgetStateProperty<TextStyle?>? trailingTextStyle;
+  final TextStyle? trailingTextStyle;
 
   /// The background color of the trailing badge.
   ///
@@ -104,8 +104,8 @@ class SBBChipStyle {
     WidgetStateProperty<Color?>? backgroundColor,
     WidgetStateProperty<Color?>? labelForegroundColor,
     WidgetStateProperty<Color?>? trailingForegroundColor,
-    WidgetStateProperty<TextStyle?>? labelTextStyle,
-    WidgetStateProperty<TextStyle?>? trailingTextStyle,
+    TextStyle? labelTextStyle,
+    TextStyle? trailingTextStyle,
     WidgetStateProperty<Color?>? trailingBackgroundColor,
     WidgetStateProperty<Color?>? overlayColor,
   }) {
@@ -154,13 +154,8 @@ class SBBChipStyle {
         t,
         Color.lerp,
       ),
-      labelTextStyle: WidgetStateProperty.lerp<TextStyle?>(a?.labelTextStyle, b?.labelTextStyle, t, TextStyle.lerp),
-      trailingTextStyle: WidgetStateProperty.lerp<TextStyle?>(
-        a?.trailingTextStyle,
-        b?.trailingTextStyle,
-        t,
-        TextStyle.lerp,
-      ),
+      labelTextStyle: TextStyle.lerp(a?.labelTextStyle, b?.labelTextStyle, t),
+      trailingTextStyle: TextStyle.lerp(a?.trailingTextStyle, b?.trailingTextStyle, t),
       trailingBackgroundColor: WidgetStateProperty.lerp<Color?>(
         a?.trailingBackgroundColor,
         b?.trailingBackgroundColor,

--- a/lib/src/list_item/sbb_list_item.dart
+++ b/lib/src/list_item/sbb_list_item.dart
@@ -395,8 +395,8 @@ class _SBBListItemState extends State<SBBListItem> {
     final effectiveSubtitleGapHeight = widget.subtitleVerticalGapHeight ?? themeData.subtitleVerticalGapHeight!;
     final effectiveOverlayColor = effectiveStyle.overlayColor;
 
-    final resolvedTitleTextStyle = effectiveStyle.titleTextStyle?.resolve(states);
-    final resolvedSubtitleTextStyle = effectiveStyle.subtitleTextStyle?.resolve(states);
+    final resolvedTitleTextStyle = effectiveStyle.titleTextStyle;
+    final resolvedSubtitleTextStyle = effectiveStyle.subtitleTextStyle;
     final resolvedTitleForegroundColor = effectiveStyle.titleForegroundColor?.resolve(states);
     final resolvedSubtitleForegroundColor = effectiveStyle.subtitleForegroundColor?.resolve(states);
     final resolvedLeadingForegroundColor = effectiveStyle.leadingForegroundColor?.resolve(states);

--- a/lib/src/list_item/theme/default_sbb_list_item_theme_data.dart
+++ b/lib/src/list_item/theme/default_sbb_list_item_theme_data.dart
@@ -11,12 +11,8 @@ class DefaultSBBListItemThemeData extends SBBListItemThemeData {
         leadingHorizontalGapWidth: 8.0,
         subtitleVerticalGapHeight: 4.0,
         style: SBBListItemStyle(
-          titleTextStyle: WidgetStateProperty.fromMap(<WidgetStatesConstraint, TextStyle?>{
-            WidgetState.any: baseStyle.themedTextStyle(textStyle: baseStyle.textTheme.mediumLight),
-          }),
-          subtitleTextStyle: WidgetStateProperty.fromMap(<WidgetStatesConstraint, TextStyle?>{
-            WidgetState.any: baseStyle.themedTextStyle(textStyle: baseStyle.textTheme.smallLight),
-          }),
+          titleTextStyle: baseStyle.textTheme.mediumLight,
+          subtitleTextStyle: baseStyle.textTheme.smallLight,
           titleForegroundColor: WidgetStateProperty.fromMap(<WidgetStatesConstraint, Color?>{
             WidgetState.disabled: baseStyle.colorScheme.textSecondary,
             WidgetState.any: baseStyle.colorScheme.textPrimary,

--- a/lib/src/list_item/theme/sbb_list_item_style.dart
+++ b/lib/src/list_item/theme/sbb_list_item_style.dart
@@ -45,7 +45,7 @@ class SBBListItemStyle {
   ///
   /// The color of the [titleTextStyle] is typically not used directly, the
   /// [titleForegroundColor] is used instead.
-  final WidgetStateProperty<TextStyle?>? titleTextStyle;
+  final TextStyle? titleTextStyle;
 
   /// The text style for the list item subtitle.
   ///
@@ -53,7 +53,7 @@ class SBBListItemStyle {
   ///
   /// The color of the [subtitleTextStyle] is typically not used directly, the
   /// [subtitleForegroundColor] is used instead.
-  final WidgetStateProperty<TextStyle?>? subtitleTextStyle;
+  final TextStyle? subtitleTextStyle;
 
   /// The color of the title text.
   ///
@@ -89,8 +89,8 @@ class SBBListItemStyle {
   static EdgeInsets get defaultPadding => .symmetric(horizontal: 16.0, vertical: 10.0);
 
   SBBListItemStyle copyWith({
-    WidgetStateProperty<TextStyle?>? titleTextStyle,
-    WidgetStateProperty<TextStyle?>? subtitleTextStyle,
+    TextStyle? titleTextStyle,
+    TextStyle? subtitleTextStyle,
     WidgetStateProperty<Color?>? titleForegroundColor,
     WidgetStateProperty<Color?>? subtitleForegroundColor,
     WidgetStateProperty<Color?>? leadingForegroundColor,
@@ -129,13 +129,8 @@ class SBBListItemStyle {
     if (identical(a, b)) return a;
 
     return SBBListItemStyle(
-      titleTextStyle: WidgetStateProperty.lerp<TextStyle?>(a?.titleTextStyle, b?.titleTextStyle, t, TextStyle.lerp),
-      subtitleTextStyle: WidgetStateProperty.lerp<TextStyle?>(
-        a?.subtitleTextStyle,
-        b?.subtitleTextStyle,
-        t,
-        TextStyle.lerp,
-      ),
+      titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
+      subtitleTextStyle: TextStyle.lerp(a?.subtitleTextStyle, b?.subtitleTextStyle, t),
       titleForegroundColor: WidgetStateProperty.lerp<Color?>(
         a?.titleForegroundColor,
         b?.titleForegroundColor,


### PR DESCRIPTION
In SBBStepper and SBBSegmentedButton, it makes sense to leave them, as the text style is de facto dependent on the state.

Sorry @rawi-coding, I missed some places...