### PR TITLE
refactor!: make context mandatory in divideItems (#656)

### DIFF
--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -219,12 +219,13 @@ class _ScrollablePageState extends State<ScrollablePage> {
             duration: Durations.long4,
           ),
         ),
-        SliverList.builder(
+        SliverList.separated(
           itemCount: 60,
           itemBuilder: (context, index) => SBBListItem(
             titleText: 'Item $index',
             onTap: () => sbbToast.show(titleText: 'Pressed Item $index', bottom: 96.0),
           ),
+          separatorBuilder: SBBDivider.separatorBuilder,
         ),
       ],
     );

--- a/example/lib/pages/header_box_page.floating.dart
+++ b/example/lib/pages/header_box_page.floating.dart
@@ -37,7 +37,7 @@ class _FloatingPageState extends State<FloatingPage> {
                 flapMode: .hideable,
               ),
             ),
-            SliverList.builder(
+            SliverList.separated(
               itemCount: 60,
               itemBuilder: (context, index) => SBBListItem(
                 titleText: 'Item $index',
@@ -46,6 +46,7 @@ class _FloatingPageState extends State<FloatingPage> {
                   sbbToast.show(titleText: 'Pressed Item $index', bottom: 96.0);
                 },
               ),
+              separatorBuilder: SBBDivider.separatorBuilder,
             ),
             const SBBSliverHeaderBoxSpacer(),
           ],

--- a/example/lib/pages/list_item_page.dart
+++ b/example/lib/pages/list_item_page.dart
@@ -129,7 +129,7 @@ class ListItemPage extends StatelessWidget {
                 onTap: () {},
                 titleText: 'Index ${idx + 1}',
               ),
-              separatorBuilder: (_, _) => SBBDivider(),
+              separatorBuilder: SBBDivider.separatorBuilder,
             ),
           ),
         ],

--- a/lib/src/list_item/sbb_list_item.dart
+++ b/lib/src/list_item/sbb_list_item.dart
@@ -288,7 +288,7 @@ class SBBListItem extends StatefulWidget {
   /// Consider using [SBBDivider.divideItems] instead of this.
   @Deprecated('Use SBBDivider.divideItems instead of this method.')
   static List<Widget> divideListItems({
-    BuildContext? context,
+    required BuildContext context,
     required Iterable<Widget> items,
     Color? color,
   }) => SBBDivider.divideItems(items: items, context: context, color: color);

--- a/lib/src/shared/divider/sbb_divider.dart
+++ b/lib/src/shared/divider/sbb_divider.dart
@@ -19,18 +19,17 @@ class SBBDivider extends StatelessWidget {
   /// [ThemeData.dividerColor] of the context's [Theme] is used, which defaults to
   /// [SBBBaseStyle.dividerColor].
   static List<Widget> divideItems({
-    BuildContext? context,
+    required BuildContext context,
     required Iterable<Widget> items,
     Color? color,
   }) {
-    assert(color != null || context != null);
-    items = items.toList();
+    final itemList = items.toList();
 
-    if (items.isEmpty || items.length == 1) {
-      return items.toList();
+    if (itemList.isEmpty || itemList.length == 1) {
+      return itemList;
     }
 
-    final resolvedColor = color ?? Theme.of(context!).dividerColor;
+    final resolvedColor = color ?? Theme.of(context).dividerColor;
 
     Widget wrapListItem(Widget link) {
       return CustomPaint(
@@ -43,7 +42,7 @@ class SBBDivider extends StatelessWidget {
       );
     }
 
-    return <Widget>[...items.take(items.length - 1).map(wrapListItem), items.last];
+    return <Widget>[...itemList.take(itemList.length - 1).map(wrapListItem), itemList.last];
   }
 
   @override

--- a/lib/src/shared/divider/sbb_divider.dart
+++ b/lib/src/shared/divider/sbb_divider.dart
@@ -5,8 +5,38 @@ import 'package:sbb_design_system_mobile/src/shared/divider/divider_painter.dart
 
 /// A one-pixel divider line using the SBB design system styling.
 ///
+/// ## Sample code for standard use
+///
+/// ```dart
+/// Column(
+///   children: SBBDivider.divideItems(
+///     context: context,
+///     items: [
+///       SBBListItem(titleText: 'Item 1'),
+///       SBBListItem(titleText: 'Item 2'),
+///       SBBListItem(titleText: 'Item 3'),
+///     ],
+///   )
+/// )
+/// ```
+///
+///
+/// {@template sbb_design_system.divider.sample_builder}
+/// ## Sample code for item builders
+///
+/// ```dart
+/// SliverList.separated(
+///   itemBuilder: (context, index) => SBBListItem(
+///     titleText: 'Item $index',
+///   ),
+///   separatorBuilder: SBBDivider.separatorBuilder,
+/// ),
+/// ```
+/// {@endtemplate}
+///
 /// See also:
 ///  * [SBBDivider.divideItems], for automatically adding dividers between list items.
+///  * [SBBDivider.separatorBuilder], for a convenience function when using separated item builders.
 class SBBDivider extends StatelessWidget {
   const SBBDivider({super.key, this.color});
 
@@ -18,6 +48,8 @@ class SBBDivider extends StatelessWidget {
   /// Add a one pixel border in between each item. If color isn't specified the
   /// [ThemeData.dividerColor] of the context's [Theme] is used, which defaults to
   /// [SBBBaseStyle.dividerColor].
+  ///
+  /// When working with an item builder, consider using [separatorBuilder].
   static List<Widget> divideItems({
     required BuildContext context,
     required Iterable<Widget> items,
@@ -43,6 +75,13 @@ class SBBDivider extends StatelessWidget {
     }
 
     return <Widget>[...itemList.take(itemList.length - 1).map(wrapListItem), itemList.last];
+  }
+
+  /// A convenience function to for use in separated item builders.
+  ///
+  /// {@macro sbb_design_system.divider.sample_builder}
+  static Widget separatorBuilder(BuildContext _, int _) {
+    return SBBDivider();
   }
 
   @override


### PR DESCRIPTION
This changes the following:

- Make context mandatory.
- Add more documentation.
- Add a convenience function for separator builder.

I'm honestly a bit torn on the last one, but I think it's a little cleaner from the user's perspective than having to use a lambda function.