### PR TITLE
fix(toast): propagate material properties to toast

### DIFF
--- a/lib/src/toast/sbb_toast.dart
+++ b/lib/src/toast/sbb_toast.dart
@@ -221,7 +221,14 @@ class SBBToast {
           bottom: bottom,
           child: Align(
             alignment: .center,
-            child: Semantics(container: true, liveRegion: true, child: builder(context, stream)),
+            child: Material(
+              type: .transparency,
+              child: Semantics(
+                container: true,
+                liveRegion: true,
+                child: builder(context, stream),
+              ),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
The issue seems to be that the `OverlayEntry` does not have material attributes, or more precisely a `DefaultTextStyle`.
The toast then uses `DefaultTextStyle.merge` to merge the effectively uninitiated fallback text style with our own text style (which has some `null` values that are then filled in incorrectly).

Instead of using `Material` we could also not merge the text styles at all, but I thought this might be more robust in case the user uses a custom widget.

The tests ran through because they are rendered in the normal widget tree.

Fixes #666 