### PR TITLE
chore(example): align content padding with header-box

### DIFF
--- a/example/lib/native_app.dart
+++ b/example/lib/native_app.dart
@@ -91,7 +91,7 @@ class MyApp extends StatelessWidget {
           slivers: [
             ThemeSliverHeaderbox(),
             SliverPadding(
-              padding: const .symmetric(horizontal: SBBSpacing.medium),
+              padding: const .symmetric(horizontal: SBBSpacing.xSmall),
               sliver: SliverList.list(
                 children: [
                   const SBBListHeader('Basics'),


### PR DESCRIPTION
Micro change because it was bothering me that the list was not aligned with the header-box.