### PR TITLE
feat: add flap decoration parameter to header box style (#456)

### DIFF
--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -81,71 +81,130 @@ class DesignGuidelinePage extends StatefulWidget {
 
 class _DesignGuidelinePageState extends State<DesignGuidelinePage> {
   bool flapEnabled = true;
+  bool colorful = false;
 
   @override
   Widget build(BuildContext context) {
     final sbbToast = SBBToast.of(context);
-    return DemoPageScaffold(
-      body: Column(
-        children: [
-          SBBCheckboxListItemBoxed(
-            titleText: 'Show flap',
-            value: flapEnabled,
-            onChanged: (value) => setState(() {
-              flapEnabled = value!;
-            }),
-          ),
-          const SizedBox(height: SBBSpacing.medium),
-          const SBBListHeader('Default'),
-          SBBHeaderBox(
-            titleText: 'Title',
-            leadingIconData: SBBIcons.unicorn_small,
-            subtitleText: 'Subtext',
-            flap: flapEnabled
-                ? SBBHeaderBoxFlap(
-                    labelText: 'Additional text or information',
-                    leadingIconData: SBBIcons.sign_exclamation_point_small,
-                    trailingIconData: SBBIcons.circle_information_small,
-                  )
-                : null,
-            trailing: SBBTertiaryButtonSmall(
-              labelText: 'Label',
-              iconData: SBBIcons.dog_small,
-              onPressed: () => sbbToast.show(titleText: 'Default pressed', bottom: 96.0),
+    return AnimatedTheme(
+      data: _theme(context),
+      child: DemoPageScaffold(
+        body: Column(
+          children: [
+            SBBContentBox(
+              child: Column(
+                children: [
+                  SBBCheckboxListItem(
+                    titleText: 'Show flap',
+                    value: flapEnabled,
+                    onChanged: (value) => setState(() {
+                      flapEnabled = value!;
+                    }),
+                  ),
+                  SBBCheckboxListItem(
+                    titleText: 'Colorful',
+                    value: colorful,
+                    onChanged: !flapEnabled
+                        ? null
+                        : (value) => setState(() {
+                            colorful = value!;
+                          }),
+                  ),
+                ],
+              ),
             ),
-          ),
-          const SizedBox(height: SBBSpacing.medium),
-          const SBBListHeader('Large'),
-          SBBHeaderBoxLarge(
-            titleText: 'Title',
-            leadingIconData: SBBIcons.unicorn_small,
-            subtitleText: 'Subtext',
-            trailing: SBBTertiaryButton(
-              iconData: SBBIcons.dog_small,
-              onPressed: () => sbbToast.show(titleText: 'Large pressed', bottom: 96.0),
+
+            const SizedBox(height: SBBSpacing.medium),
+            const SBBListHeader('Default'),
+            SBBHeaderBox(
+              titleText: 'Title',
+              leadingIconData: SBBIcons.unicorn_small,
+              subtitleText: 'Subtext',
+              flap: flapEnabled
+                  ? SBBHeaderBoxFlap(
+                      labelText: 'Additional text or information',
+                      leadingIconData: SBBIcons.sign_exclamation_point_small,
+                      trailingIconData: SBBIcons.circle_information_small,
+                    )
+                  : null,
+              trailing: SBBTertiaryButtonSmall(
+                labelText: 'Label',
+                iconData: SBBIcons.dog_small,
+                onPressed: () => sbbToast.show(titleText: 'Default pressed', bottom: 96.0),
+              ),
             ),
-            flap: flapEnabled
-                ? SBBHeaderBoxFlap(
-                    labelText: 'Additional text or information',
-                    leadingIconData: SBBIcons.sign_exclamation_point_small,
-                    trailingIconData: SBBIcons.circle_information_small,
-                  )
-                : null,
-          ),
-          const SizedBox(height: SBBSpacing.medium),
-          const SBBListHeader('Custom'),
-          SBBHeaderBox(
-            padding: .zero,
-            flap: flapEnabled
-                ? SBBHeaderBoxFlap(
-                    label: Center(child: Text('Choooooo!', style: SBBTextStyles.xSmallBold)),
-                  )
-                : null,
-            title: Center(child: Text('🚂｡🚋｡🚋｡🚋｡🚋˙⊹⁺.')),
-            isLoading: true,
-          ),
-        ],
+            const SizedBox(height: SBBSpacing.medium),
+            const SBBListHeader('Large'),
+            SBBHeaderBoxLarge(
+              titleText: 'Title',
+              leadingIconData: SBBIcons.unicorn_small,
+              subtitleText: 'Subtext',
+              trailing: SBBTertiaryButton(
+                iconData: SBBIcons.dog_small,
+                onPressed: () => sbbToast.show(titleText: 'Large pressed', bottom: 96.0),
+              ),
+              flap: flapEnabled
+                  ? SBBHeaderBoxFlap(
+                      labelText: 'Additional text or information',
+                      leadingIconData: SBBIcons.sign_exclamation_point_small,
+                      trailingIconData: SBBIcons.circle_information_small,
+                    )
+                  : null,
+            ),
+            const SizedBox(height: SBBSpacing.medium),
+            const SBBListHeader('Custom'),
+            SBBHeaderBox(
+              padding: .zero,
+              flap: flapEnabled
+                  ? SBBHeaderBoxFlap(
+                      label: Center(child: Text('Choooooo!', style: SBBTextStyles.xSmallBold)),
+                    )
+                  : null,
+              title: Center(child: Text('🚂｡🚋｡🚋｡🚋｡🚋˙⊹⁺.')),
+              isLoading: true,
+            ),
+          ],
+        ),
       ),
+    );
+  }
+
+  ThemeData _theme(BuildContext context) {
+    final theme = Theme.of(context);
+    final decoration = colorful
+        ? BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                SBBColors.red,
+                SBBColors.blue,
+              ],
+            ),
+          )
+        : null;
+
+    final flapStyle = colorful
+        ? SBBHeaderBoxFlapStyle(
+            labelForegroundColor: SBBColors.white,
+            leadingForegroundColor: SBBColors.white,
+            trailingForegroundColor: SBBColors.white,
+          )
+        : null;
+
+    return theme.copyWith(
+      extensions: [
+        ...theme.extensions.values,
+        theme.sbbHeaderBoxTheme.merge(
+          SBBHeaderBoxThemeData(
+            flapStyle: flapStyle,
+            style: SBBHeaderBoxStyle(
+              flapDecoration: decoration,
+            ),
+            largeStyle: SBBHeaderBoxStyle(
+              flapDecoration: decoration,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/example/lib/pages/header_box_page.dart
+++ b/example/lib/pages/header_box_page.dart
@@ -72,8 +72,15 @@ class _HeaderBoxPageState extends State<HeaderBoxPage> {
   }
 }
 
-class DesignGuidelinePage extends StatelessWidget {
+class DesignGuidelinePage extends StatefulWidget {
   const DesignGuidelinePage({super.key});
+
+  @override
+  State<DesignGuidelinePage> createState() => _DesignGuidelinePageState();
+}
+
+class _DesignGuidelinePageState extends State<DesignGuidelinePage> {
+  bool flapEnabled = true;
 
   @override
   Widget build(BuildContext context) {
@@ -81,16 +88,26 @@ class DesignGuidelinePage extends StatelessWidget {
     return DemoPageScaffold(
       body: Column(
         children: [
+          SBBCheckboxListItemBoxed(
+            titleText: 'Show flap',
+            value: flapEnabled,
+            onChanged: (value) => setState(() {
+              flapEnabled = value!;
+            }),
+          ),
+          const SizedBox(height: SBBSpacing.medium),
           const SBBListHeader('Default'),
           SBBHeaderBox(
             titleText: 'Title',
             leadingIconData: SBBIcons.unicorn_small,
             subtitleText: 'Subtext',
-            flap: SBBHeaderBoxFlap(
-              labelText: 'Additional text or information',
-              leadingIconData: SBBIcons.sign_exclamation_point_small,
-              trailingIconData: SBBIcons.circle_information_small,
-            ),
+            flap: flapEnabled
+                ? SBBHeaderBoxFlap(
+                    labelText: 'Additional text or information',
+                    leadingIconData: SBBIcons.sign_exclamation_point_small,
+                    trailingIconData: SBBIcons.circle_information_small,
+                  )
+                : null,
             trailing: SBBTertiaryButtonSmall(
               labelText: 'Label',
               iconData: SBBIcons.dog_small,
@@ -107,14 +124,23 @@ class DesignGuidelinePage extends StatelessWidget {
               iconData: SBBIcons.dog_small,
               onPressed: () => sbbToast.show(titleText: 'Large pressed', bottom: 96.0),
             ),
+            flap: flapEnabled
+                ? SBBHeaderBoxFlap(
+                    labelText: 'Additional text or information',
+                    leadingIconData: SBBIcons.sign_exclamation_point_small,
+                    trailingIconData: SBBIcons.circle_information_small,
+                  )
+                : null,
           ),
           const SizedBox(height: SBBSpacing.medium),
           const SBBListHeader('Custom'),
-          const SBBHeaderBox(
+          SBBHeaderBox(
             padding: .zero,
-            flap: SBBHeaderBoxFlap(
-              label: Center(child: Text('Choooooo!', style: SBBTextStyles.xSmallBold)),
-            ),
+            flap: flapEnabled
+                ? SBBHeaderBoxFlap(
+                    label: Center(child: Text('Choooooo!', style: SBBTextStyles.xSmallBold)),
+                  )
+                : null,
             title: Center(child: Text('🚂｡🚋｡🚋｡🚋｡🚋˙⊹⁺.')),
             isLoading: true,
           ),

--- a/lib/src/header_box/header_box_foreground.dart
+++ b/lib/src/header_box/header_box_foreground.dart
@@ -35,7 +35,7 @@ class HeaderBoxForeground extends StatelessWidget {
         ),
         child: _column(
           _headerBox(context, style),
-          flap,
+          _animatedFlap(),
         ),
       ),
     );
@@ -73,6 +73,23 @@ class HeaderBoxForeground extends StatelessWidget {
           ],
         );
     }
+  }
+
+  Widget _animatedFlap() {
+    return AnimatedSwitcher(
+      duration: kThemeAnimationDuration,
+      switchInCurve: Curves.easeInOutCubic,
+      switchOutCurve: Curves.easeInOutCubic,
+      transitionBuilder: (child, animation) {
+        return SizeTransition(
+          sizeFactor: animation,
+          axis: .vertical,
+          axisAlignment: 1.0,
+          child: child,
+        );
+      },
+      child: flap,
+    );
   }
 
   Widget _headerBox(BuildContext context, SBBHeaderBoxStyle style) {

--- a/lib/src/header_box/header_box_foreground.dart
+++ b/lib/src/header_box/header_box_foreground.dart
@@ -23,16 +23,25 @@ class HeaderBoxForeground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final baseDecoration = BoxDecoration(
+      boxShadow: style.headerBoxShadow,
+      borderRadius: SBBHeaderBoxStyle.radius,
+      color: style.flapBackgroundColor,
+    );
     return Semantics(
       header: true,
       label: semanticsLabel,
       child: Container(
         clipBehavior: .hardEdge,
-        decoration: BoxDecoration(
-          boxShadow: style.headerBoxShadow,
-          borderRadius: SBBHeaderBoxStyle.radius,
-          color: style.flapBackgroundColor,
-        ),
+        decoration: switch (style.flapDecoration) {
+          final BoxDecoration decoration => decoration.copyWith(
+            boxShadow: decoration.boxShadow ?? baseDecoration.boxShadow,
+            borderRadius: decoration.borderRadius ?? baseDecoration.borderRadius,
+            color: decoration.color ?? baseDecoration.color,
+          ),
+          final Decoration decoration => decoration,
+          null => baseDecoration,
+        },
         child: _column(
           _headerBox(context, style),
           _animatedFlap(),

--- a/lib/src/header_box/theme/sbb_header_box_style.dart
+++ b/lib/src/header_box/theme/sbb_header_box_style.dart
@@ -34,6 +34,7 @@ class SBBHeaderBoxStyle {
     // Container / box
     this.backgroundColor,
     this.flapBackgroundColor,
+    this.flapDecoration,
     this.headerBoxShadow,
     this.shadowOverFlap,
     this.padding,
@@ -125,6 +126,13 @@ class SBBHeaderBoxStyle {
   /// This is used for the area below the main header box when a flap is shown.
   final Color? flapBackgroundColor;
 
+  /// The background decoration of a flap.
+  ///
+  /// This is used for the area below the main header box when a flap is shown.
+  ///
+  /// If the decoration is a [BoxDecoration], it will receive default values (color, radius, and shadow).
+  final Decoration? flapDecoration;
+
   /// The shadows painted around the main header box container.
   final List<BoxShadow>? headerBoxShadow;
 
@@ -169,6 +177,7 @@ class SBBHeaderBoxStyle {
     Color? trailingForegroundColor,
     Color? backgroundColor,
     Color? flapBackgroundColor,
+    Decoration? flapDecoration,
     List<BoxShadow>? headerBoxShadow,
     List<BoxShadow>? shadowOverFlap,
     EdgeInsetsGeometry? padding,
@@ -187,6 +196,7 @@ class SBBHeaderBoxStyle {
       trailingForegroundColor: trailingForegroundColor ?? this.trailingForegroundColor,
       backgroundColor: backgroundColor ?? this.backgroundColor,
       flapBackgroundColor: flapBackgroundColor ?? this.flapBackgroundColor,
+      flapDecoration: flapDecoration ?? this.flapDecoration,
       headerBoxShadow: headerBoxShadow ?? this.headerBoxShadow,
       shadowOverFlap: shadowOverFlap ?? this.shadowOverFlap,
       padding: padding ?? this.padding,
@@ -212,6 +222,7 @@ class SBBHeaderBoxStyle {
       trailingForegroundColor: other.trailingForegroundColor ?? trailingForegroundColor,
       backgroundColor: other.backgroundColor ?? backgroundColor,
       flapBackgroundColor: other.flapBackgroundColor ?? flapBackgroundColor,
+      flapDecoration: other.flapDecoration ?? flapDecoration,
       headerBoxShadow: other.headerBoxShadow ?? headerBoxShadow,
       shadowOverFlap: other.shadowOverFlap ?? shadowOverFlap,
       padding: other.padding ?? padding,
@@ -240,6 +251,7 @@ class SBBHeaderBoxStyle {
       trailingForegroundColor: Color.lerp(a?.trailingForegroundColor, b?.trailingForegroundColor, t),
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       flapBackgroundColor: Color.lerp(a?.flapBackgroundColor, b?.flapBackgroundColor, t),
+      flapDecoration: Decoration.lerp(a?.flapDecoration, b?.flapDecoration, t),
       headerBoxShadow: BoxShadow.lerpList(a?.headerBoxShadow, b?.headerBoxShadow, t),
       shadowOverFlap: BoxShadow.lerpList(a?.shadowOverFlap, b?.shadowOverFlap, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
@@ -264,6 +276,7 @@ class SBBHeaderBoxStyle {
           trailingForegroundColor == other.trailingForegroundColor &&
           backgroundColor == other.backgroundColor &&
           flapBackgroundColor == other.flapBackgroundColor &&
+          flapDecoration == other.flapDecoration &&
           headerBoxShadow == other.headerBoxShadow &&
           shadowOverFlap == other.shadowOverFlap &&
           padding == other.padding &&
@@ -283,6 +296,7 @@ class SBBHeaderBoxStyle {
     trailingForegroundColor,
     backgroundColor,
     flapBackgroundColor,
+    flapDecoration,
     headerBoxShadow,
     shadowOverFlap,
     padding,


### PR DESCRIPTION
- Introduces a `flapDecoration` to allow for more control over the flap style. (Closes #456)
- Adds an animation when the flap is added / removed. (Input from #520)

By the way, the reason for not putting the flap color and decoration in the flap style itself, is that the header-box draws the background and the flap only takes care of the layout.