### PR TITLE
fix: focus text input when tapping error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 It is expected that you keep this format strictly, since we depend on it in our release workflow.
 
+## [Unreleased]
+
+### Fixed
+
+- `SBBTextInput`: request focus for the input field when tapping the visible error message area
+
 ## [5.0.0] - 2026-06-19
 
 ### Added

--- a/lib/src/input/decoration/sbb_input_decorator.dart
+++ b/lib/src/input/decoration/sbb_input_decorator.dart
@@ -23,6 +23,7 @@ class SBBInputDecorator extends StatefulWidget {
     this.isEmpty = false,
     this.isBoxed = false,
     this.states = const <WidgetState>{},
+    this.onErrorTap,
     this.child,
   });
 
@@ -52,6 +53,12 @@ class SBBInputDecorator extends StatefulWidget {
 
   /// The states of the input field.
   final Set<WidgetState> states;
+
+  /// Called when the visible error message area is tapped.
+  ///
+  /// Used to request focus for the input field so that tapping the error
+  /// message behaves the same as tapping the input itself.
+  final VoidCallback? onErrorTap;
 
   /// The widget below this decorator, usually some sort of [EditableText].
   final Widget? child;
@@ -329,6 +336,13 @@ class _SBBInputDecoratorState extends State<SBBInputDecorator> with SingleTicker
         foregroundColor: resolvedColor,
         textStyle: textStyle,
       );
+      if (widget.onErrorTap != null) {
+        error = GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: widget.onErrorTap,
+          child: error,
+        );
+      }
     }
     error = AnimatedSwitcher(
       duration: _kTransitionDuration,

--- a/lib/src/input/sbb_text_input.dart
+++ b/lib/src/input/sbb_text_input.dart
@@ -499,6 +499,7 @@ class _SBBTextInputState extends State<SBBTextInput>
                       isEmpty: _effectiveController.text.isEmpty,
                       isBoxed: isBoxed,
                       states: Set<WidgetState>.from(_statesController.value),
+                      onErrorTap: _handleErrorTap,
                       child: child,
                     );
                   },
@@ -514,6 +515,18 @@ class _SBBTextInputState extends State<SBBTextInput>
 
   void _requestKeyboard() {
     _editableText?.requestKeyboard();
+  }
+
+  /// Requests focus for the input field when the visible error message is tapped.
+  ///
+  /// This mirrors the focus behavior of tapping the input itself and works for
+  /// both an externally provided and an internally managed [FocusNode].
+  void _handleErrorTap() {
+    if (_effectiveFocusNode.canRequestFocus && !_effectiveFocusNode.hasFocus) {
+      _effectiveFocusNode.requestFocus();
+    } else if (!widget.readOnly) {
+      _requestKeyboard();
+    }
   }
 
   TextStyle _effectiveInputTextStyle(BuildContext context) {

--- a/test/sbb_text_input_test.dart
+++ b/test/sbb_text_input_test.dart
@@ -164,6 +164,32 @@ void main() {
       find.byType(Column).first,
     );
   });
+
+  testWidgets('tapping the error message requests focus for the input', (WidgetTester tester) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    const errorText = 'This is an error!';
+    await tester.pumpWidget(
+      TestApp(
+        child: SBBTextInput(
+          focusNode: focusNode,
+          decoration: const SBBInputDecoration(
+            labelText: 'Error message',
+            errorText: errorText,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(focusNode.hasFocus, isFalse);
+
+    await tester.tap(find.text(errorText));
+    await tester.pump();
+
+    expect(focusNode.hasFocus, isTrue);
+  });
 }
 
 List<Widget> _textInputItems({required ValueKey<String> pressableItemKey, required SBBInputBorderType borderType}) {


### PR DESCRIPTION
﻿Fixes #683.

## Changes
- Request focus when tapping the visible `SBBTextInput` error message area.
- Add widget test coverage for the behavior.
- Update `CHANGELOG.md`.

## Checks
- `dart format --page-width 120 --trailing-commas=preserve .`
- `flutter test test/sbb_text_input_test.dart --plain-name "tapping the error message requests focus for the input"`
- `flutter analyze lib test example`

## Note
Full local `flutter test` on Windows reports golden image diffs in unrelated components. The targeted behavior test passes and package source analysis is clean.
