### PR TITLE
feat: expose bottom sheet close button key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 It is expected that you keep this format strictly, since we depend on it in our release workflow.
 
+## [Unreleased]
+
+### Added
+
+- `SBBBottomSheet`: expose `SBBBottomSheet.closeButtonKey`, a stable key for the internal close button
+
 ## [5.0.0] - 2026-06-19
 
 ### Added

--- a/lib/src/bottom_sheet/sbb_bottom_sheet.dart
+++ b/lib/src/bottom_sheet/sbb_bottom_sheet.dart
@@ -193,6 +193,17 @@ class SBBBottomSheet extends StatelessWidget {
     this.style,
   });
 
+  /// The [Key] applied to the internal close button shown in the header when
+  /// [showCloseButton] is `true`.
+  ///
+  /// Use it to reliably find and tap the close button in widget and integration
+  /// tests without relying on internal implementation details:
+  ///
+  /// ```dart
+  /// await tester.tap(find.byKey(SBBBottomSheet.closeButtonKey));
+  /// ```
+  static const closeButtonKey = Key('sbb_bottom_sheet_close_button');
+
   /// {@template sbb_design_system.sbb_bottom_sheet.title}
   /// A custom widget displayed as the sheet's title.
   ///
@@ -423,6 +434,7 @@ class _CloseButton extends StatelessWidget {
     excludeSemantics: true,
     button: true,
     child: SBBTertiaryButtonSmall(
+      key: SBBBottomSheet.closeButtonKey,
       onPressed: () => Navigator.of(context, rootNavigator: useRootNavigator).pop(),
       iconData: SBBIcons.cross_small,
     ),

--- a/test/sbb_bottom_sheet_test.dart
+++ b/test/sbb_bottom_sheet_test.dart
@@ -18,6 +18,44 @@ void main() {
   }
 
   generateTest('bottom_sheet_test_1');
+
+  testWidgets('close button is reachable via SBBBottomSheet.closeButtonKey and dismisses the sheet', (
+    WidgetTester tester,
+  ) async {
+    const bodyText = 'Bottom sheet body';
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SBBTheme.light(),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showSBBBottomSheet(
+                  context: context,
+                  titleText: 'Title',
+                  body: const Text(bodyText),
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Open the bottom sheet.
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text(bodyText), findsOneWidget);
+
+    // The close button can be found by its public key.
+    expect(find.byKey(SBBBottomSheet.closeButtonKey), findsOneWidget);
+
+    // Tapping the close button by key dismisses the sheet.
+    await tester.tap(find.byKey(SBBBottomSheet.closeButtonKey));
+    await tester.pumpAndSettle();
+    expect(find.text(bodyText), findsNothing);
+  });
 }
 
 class ModalSheetTest extends StatelessWidget {


### PR DESCRIPTION
﻿Fixes #691.

## Changes
- Add `SBBBottomSheet.closeButtonKey` as a stable public key for the internal close button.
- Apply the key to the bottom sheet close button.
- Add widget test coverage for finding and tapping the close button by key.
- Update `CHANGELOG.md`.

## Checks
- `dart format --page-width 120 --trailing-commas=preserve .`
- `flutter analyze lib test example`
- `flutter test test/sbb_bottom_sheet_test.dart --plain-name "<new close button key test name>"`

## Note
The targeted new widget test passes and package source analysis is clean. Full local bottom sheet golden tests report pre-existing Windows golden image diffs unrelated to this key-only change.
